### PR TITLE
feat: implement "Save System Bundle" use case

### DIFF
--- a/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
@@ -32,5 +32,7 @@ namespace Enrich.BLL.Interfaces
             int pageSize);
 
         Task<IEnumerable<Category>> GetAllCategoriesAsync();
+
+        Task<Result> SaveSystemBundleAsync(string userId, int bundleId);
     }
 }

--- a/Enrich/Enrich.BLL/Services/BundleService.cs
+++ b/Enrich/Enrich.BLL/Services/BundleService.cs
@@ -446,5 +446,41 @@ namespace Enrich.BLL.Services
                 TagCount = bundle.Tags?.Count ?? 0
             };
         }
+
+        public async Task<Result> SaveSystemBundleAsync(string userId, int bundleId)
+        {
+            var bundle = await bundleRepository.GetBundleByIdAsync(bundleId);
+
+            if (bundle == null || !bundle.IsSystem)
+            {
+                logger.LogWarning("Користувач {UserId} спробував зберегти неіснуючий або несистемний бандл {BundleId}.", userId, bundleId);
+                return "Collection not found or is not a system collection.";
+            }
+
+            var alreadySaved = await bundleRepository.UserHasBundleAsync(userId, bundleId);
+            if (alreadySaved)
+            {
+                return "You have already saved this collection.";
+            }
+
+            var userBundle = new UserBundle
+            {
+                UserId = userId,
+                BundleId = bundleId,
+                SavedAt = DateTime.UtcNow
+            };
+
+            try
+            {
+                await bundleRepository.SaveUserBundleAsync(userBundle);
+                logger.LogInformation("Користувач {UserId} успішно зберіг системний бандл {BundleId}.", userId, bundleId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Помилка при збереженні системного бандлу {BundleId} користувачем {UserId}.", bundleId, userId);
+                return "An error occurred while saving the collection.";
+            }
+        }
     }
 }

--- a/Enrich/Enrich.DAL/Interfaces/IBundleRepository.cs
+++ b/Enrich/Enrich.DAL/Interfaces/IBundleRepository.cs
@@ -36,5 +36,9 @@ namespace Enrich.DAL.Interfaces
             int pageSize);
 
         Task<Bundle> CreateBundleAsync(Bundle bundle);
+
+        Task<bool> UserHasBundleAsync(string userId, int bundleId);
+
+        Task SaveUserBundleAsync(UserBundle userBundle);
     }
 }

--- a/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
@@ -258,5 +258,17 @@ namespace Enrich.DAL.Repositories
             await dbContext.SaveChangesAsync();
             return bundle;
         }
+
+        public async Task<bool> UserHasBundleAsync(string userId, int bundleId)
+        {
+            return await dbContext.UserBundles
+                .AnyAsync(ub => ub.UserId == userId && ub.BundleId == bundleId);
+        }
+
+        public async Task SaveUserBundleAsync(UserBundle userBundle)
+        {
+            await dbContext.UserBundles.AddAsync(userBundle);
+            await dbContext.SaveChangesAsync();
+        }
     }
 }

--- a/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
@@ -27,7 +27,7 @@ namespace Enrich.DAL.Repositories
         public async Task<IEnumerable<Bundle>> GetUserBundlesAsync(string userId)
         {
             return await dbContext.Bundles
-                .Where(b => b.OwnerId == userId)
+                .Where(b => b.OwnerId == userId || b.UserBundles.Any(ub => ub.UserId == userId))
                 .Include(b => b.Words)
                 .Include(b => b.Categories)
                 .Include(b => b.Tags)

--- a/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
@@ -47,7 +47,7 @@ namespace Enrich.DAL.Repositories
             int pageSize = 6)
         {
             var query = dbContext.Bundles
-                .Where(b => b.OwnerId == userId)
+                .Where(b => b.OwnerId == userId || b.UserBundles.Any(ub => ub.UserId == userId))
                 .Include(b => b.Words)
                 .Include(b => b.Categories)
                 .Include(b => b.Tags)

--- a/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
@@ -316,5 +316,84 @@ namespace Enrich.UnitTests.Services
             Assert.That(result.Select(c => c.Name), Contains.Item("Technology"));
             _categoryRepositoryMock.Verify(r => r.GetAllCategoriesAsync(), Times.Once);
         }
+
+        [Test]
+        public async Task SaveSystemBundleAsync_ValidSystemBundle_ReturnsSuccess()
+        {
+            // Arrange
+            var userId = "user123";
+            var bundleId = 1;
+            var systemBundle = new Bundle { Id = bundleId, IsSystem = true };
+
+            _bundleRepositoryMock
+                .Setup(r => r.GetBundleByIdAsync(bundleId))
+                .ReturnsAsync(systemBundle);
+
+            _bundleRepositoryMock
+                .Setup(r => r.UserHasBundleAsync(userId, bundleId))
+                .ReturnsAsync(false);
+
+            _bundleRepositoryMock
+                .Setup(r => r.SaveUserBundleAsync(It.IsAny<UserBundle>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _bundleService.SaveSystemBundleAsync(userId, bundleId);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+
+            _bundleRepositoryMock.Verify(
+                r => r.SaveUserBundleAsync(It.Is<UserBundle>(ub => ub.UserId == userId && ub.BundleId == bundleId)),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task SaveSystemBundleAsync_BundleNotSystem_ReturnsError()
+        {
+            // Arrange
+            var userId = "user123";
+            var bundleId = 1;
+            var nonSystemBundle = new Bundle { Id = bundleId, IsSystem = false };
+
+            _bundleRepositoryMock
+                .Setup(r => r.GetBundleByIdAsync(bundleId))
+                .ReturnsAsync(nonSystemBundle);
+
+            // Act
+            var result = await _bundleService.SaveSystemBundleAsync(userId, bundleId);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("Collection not found or is not a system collection."));
+
+            _bundleRepositoryMock.Verify(r => r.SaveUserBundleAsync(It.IsAny<UserBundle>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SaveSystemBundleAsync_AlreadySaved_ReturnsError()
+        {
+            // Arrange
+            var userId = "user123";
+            var bundleId = 1;
+            var systemBundle = new Bundle { Id = bundleId, IsSystem = true };
+
+            _bundleRepositoryMock
+                .Setup(r => r.GetBundleByIdAsync(bundleId))
+                .ReturnsAsync(systemBundle);
+
+            _bundleRepositoryMock
+                .Setup(r => r.UserHasBundleAsync(userId, bundleId))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _bundleService.SaveSystemBundleAsync(userId, bundleId);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("You have already saved this collection."));
+
+            _bundleRepositoryMock.Verify(r => r.SaveUserBundleAsync(It.IsAny<UserBundle>()), Times.Never);
+        }
     }
 }

--- a/Enrich/Enrich.Web/Controllers/BundleController.cs
+++ b/Enrich/Enrich.Web/Controllers/BundleController.cs
@@ -354,5 +354,19 @@ namespace Enrich.Web.Controllers
 
             return Ok("Слова успішно видалено з бандлу!");
         }
+
+        [HttpPost]
+        public async Task<IActionResult> SaveSystemBundle(int id)
+        {
+            var result = await bundleService.SaveSystemBundleAsync(CurrentUserId, id);
+
+            if (!result.IsSuccess)
+            {
+                logger.LogWarning("Невдала спроба зберегти системний бандл {BundleId} користувачем {UserId}: {Error}", id, CurrentUserId, result.ErrorMessage);
+                return BadRequest(new { message = result.ErrorMessage });
+            }
+
+            return Ok();
+        }
     }
 }

--- a/Enrich/Enrich.Web/Views/Collection/Index.cshtml
+++ b/Enrich/Enrich.Web/Views/Collection/Index.cshtml
@@ -150,5 +150,39 @@
                 li.style.display = q === '' || text.includes(q) ? '' : 'none';
             });
         });
+
+        async function toggleSaveBundle(bundleId, btnElement) {
+            try {
+                const response = await fetch(`/Bundle/SaveSystemBundle?id=${bundleId}`, {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'Content-Type': 'application/json'
+                    }
+                });
+
+                if (response.ok) {
+                    if (btnElement) {
+                        const icon = btnElement.querySelector('i');
+                        
+                        icon.classList.remove('bi-star');
+                        icon.classList.add('bi-star-fill');
+                        
+                        btnElement.classList.remove('text-secondary');
+                        btnElement.classList.add('text-warning'); 
+                        
+                        btnElement.title = "Saved";
+                        btnElement.disabled = true;
+                        btnElement.style.opacity = '1';
+                    }
+                } else {
+                    const error = await response.json();
+                    alert(error.message || 'Error saving the collection.');
+                }
+            } catch (err) {
+                console.error("Failed to save collection", err);
+                alert('A network error occurred.');
+            }
+        }
     </script>
 }

--- a/Enrich/Enrich.Web/Views/Collection/_BundleListPartial.cshtml
+++ b/Enrich/Enrich.Web/Views/Collection/_BundleListPartial.cshtml
@@ -30,7 +30,15 @@
                         </div>
 
                         <div class="flex-grow-1 d-flex flex-column">
-                            <h5 class="bundle-title">@bundle.Title</h5>
+                            <div class="d-flex justify-content-between align-items-start">
+                                <h5 class="bundle-title mb-0">@bundle.Title</h5>
+                                <button type="button" 
+                                        class="btn btn-link p-0 text-secondary border-0" 
+                                        title="Save collection"
+                                        onclick="toggleSaveBundle(@bundle.Id, this)">
+                                    <i class="bi bi-star fs-5"></i>
+                                </button>
+                            </div>
                             <div class="bundle-wordcount">Words: @bundle.WordCount</div>
 
                             @if (!string.IsNullOrEmpty(bundle.Description))


### PR DESCRIPTION
This PR implements the "Save System Bundle" use case as requested in #61. It allows users to save global/system collections to their personal library.

## Changes Made
* **Backend:** - Added `UserHasBundleAsync` and `SaveUserBundleAsync` to `BundleRepository`.
  - Added `SaveSystemBundleAsync` business logic to `BundleService`.
  - Created POST endpoint `SaveSystemBundle` in `BundleController`.
* **Frontend:** - Added a star button to the bundle cards in `_BundleListPartial.cshtml`.
  - Added `toggleSaveBundle` JS function in `Collection/Index.cshtml` to handle asynchronous saving and UI updates (star turning gold).

Closes #61


