### PR TITLE
feat: implement Browse and Save Community Bundles (#79, #80)

### DIFF
--- a/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
@@ -39,6 +39,15 @@ namespace Enrich.BLL.Interfaces
             int page,
             int pageSize);
 
+        Task<PagedResult<SystemBundleDTO>> GetCommunityBundlesAsync(
+            string? searchTerm,
+            string? category,
+            string? difficultyLevel,
+            int? minWordCount,
+            int? maxWordCount,
+            int page,
+            int pageSize);
+
         Task<IEnumerable<Category>> GetAllCategoriesAsync();
 
         Task<Result> SaveSystemBundleAsync(string userId, int bundleId);

--- a/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
@@ -52,6 +52,8 @@ namespace Enrich.BLL.Interfaces
 
         Task<Result> SaveSystemBundleAsync(string userId, int bundleId);
 
+        Task<Result> SaveCommunityBundleAsync(string userId, int bundleId);
+
         Task<Result> SubmitBundleForReviewAsync(string userId, int bundleId);
 
         Task<BundleDTO?> GetBundleWithWordsAsync(int bundleId);

--- a/Enrich/Enrich.BLL/Services/BundleService.cs
+++ b/Enrich/Enrich.BLL/Services/BundleService.cs
@@ -605,6 +605,42 @@ namespace Enrich.BLL.Services
             }
         }
 
+        public async Task<Result> SaveCommunityBundleAsync(string userId, int bundleId)
+        {
+            var bundle = await bundleRepository.GetBundleByIdAsync(bundleId);
+
+            if (bundle == null || bundle.IsSystem || bundle.Status != BundleStatus.Published)
+            {
+                logger.LogWarning("User {UserId} attempted to save non-existent or invalid community bundle {BundleId}.", userId, bundleId);
+                return "Collection not found or is not a valid community collection.";
+            }
+
+            var alreadySaved = await bundleRepository.UserHasBundleAsync(userId, bundleId);
+            if (alreadySaved)
+            {
+                return "You have already saved this collection.";
+            }
+
+            var userBundle = new UserBundle
+            {
+                UserId = userId,
+                BundleId = bundleId,
+                SavedAt = DateTime.UtcNow
+            };
+
+            try
+            {
+                await bundleRepository.SaveUserBundleAsync(userBundle);
+                logger.LogInformation("User {UserId} successfully saved community bundle {BundleId}.", userId, bundleId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error saving community bundle {BundleId} by user {UserId}.", bundleId, userId);
+                return "An error occurred while saving the collection.";
+            }
+        }
+
         public async Task<Result> SubmitBundleForReviewAsync(string userId, int bundleId)
         {
             var bundle = await bundleRepository.GetBundleByIdAsync(bundleId);

--- a/Enrich/Enrich.BLL/Services/BundleService.cs
+++ b/Enrich/Enrich.BLL/Services/BundleService.cs
@@ -230,6 +230,56 @@ namespace Enrich.BLL.Services
             };
         }
 
+        public async Task<PagedResult<SystemBundleDTO>> GetCommunityBundlesAsync(
+             string? searchTerm,
+             string? category,
+             string? difficultyLevel,
+             int? minWordCount,
+             int? maxWordCount,
+             int page,
+             int pageSize)
+        {
+            logger.LogInformation("Отримання сторінки ком'юніті бандлів: сторінка={Page}, розмір={PageSize}", page, pageSize);
+
+            if (page <= 0)
+            {
+                page = 1;
+            }
+
+            if (pageSize <= 0)
+            {
+                pageSize = _pagination.DefaultSystemBundlesPageSize;
+            }
+
+            var (bundles, total) = await bundleRepository.GetCommunityBundlesPageAsync(
+                searchTerm,
+                category,
+                difficultyLevel,
+                minWordCount,
+                maxWordCount,
+                page,
+                pageSize);
+
+            var items = bundles.Select(b => new SystemBundleDTO
+            {
+                Id = b.Id,
+                Title = b.Title,
+                Description = b.Description,
+                ImageUrl = b.ImageUrl,
+                WordCount = b.Words?.Count ?? 0,
+                DifficultyLevels = b.DifficultyLevels ?? [],
+                Categories = b.Categories?.Select(c => c.Name).ToList() ?? []
+            }).ToList();
+
+            return new PagedResult<SystemBundleDTO>
+            {
+                Items = items,
+                TotalCount = total,
+                Page = page,
+                PageSize = pageSize
+            };
+        }
+
         public async Task<IEnumerable<Category>> GetAllCategoriesAsync()
         {
             return await categoryRepository.GetAllCategoriesAsync();

--- a/Enrich/Enrich.DAL/Interfaces/IBundleRepository.cs
+++ b/Enrich/Enrich.DAL/Interfaces/IBundleRepository.cs
@@ -45,6 +45,15 @@ namespace Enrich.DAL.Interfaces
             int page,
             int pageSize);
 
+        Task<(IEnumerable<Bundle> Items, int Total)> GetCommunityBundlesPageAsync(
+            string? searchTerm,
+            string? category,
+            string? difficultyLevel,
+            int? minWordCount,
+            int? maxWordCount,
+            int page,
+            int pageSize);
+
         Task<Bundle> CreateBundleAsync(Bundle bundle);
 
         Task<bool> UserHasBundleAsync(string userId, int bundleId);

--- a/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/BundleRepository.cs
@@ -352,5 +352,62 @@ namespace Enrich.DAL.Repositories
                 .Include(b => b.Words)
                 .FirstOrDefaultAsync(b => b.Id == bundleId);
         }
+
+        public async Task<(IEnumerable<Bundle> Items, int Total)> GetCommunityBundlesPageAsync(
+           string? searchTerm,
+           string? category,
+           string? difficultyLevel,
+           int? minWordCount,
+           int? maxWordCount,
+           int page,
+           int pageSize)
+        {
+            var query = dbContext.Bundles
+                .Where(b => !b.IsSystem && b.Status == BundleStatus.Published)
+                .Include(b => b.Categories)
+                .Include(b => b.Words)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+            {
+                var st = searchTerm.Trim().ToLower();
+                query = query.Where(b => b.Title.ToLower().Contains(st) ||
+                                         (b.Description != null && b.Description.ToLower().Contains(st)));
+            }
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                var catsLower = category.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                       .Select(c => c.ToLower()).ToArray();
+                query = query.Where(b => b.Categories.Any(c => catsLower.Contains(c.Name.ToLower())));
+            }
+
+            if (!string.IsNullOrWhiteSpace(difficultyLevel))
+            {
+                var levelsLower = difficultyLevel.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                                .Select(l => l.ToLower()).ToArray();
+                query = query.Where(b => b.DifficultyLevels.Any(dl => levelsLower.Contains(dl.ToLower())));
+            }
+
+            if (minWordCount.HasValue)
+            {
+                query = query.Where(b => b.Words.Count >= minWordCount.Value);
+            }
+
+            if (maxWordCount.HasValue)
+            {
+                query = query.Where(b => b.Words.Count <= maxWordCount.Value);
+            }
+
+            var total = await query.CountAsync();
+
+            var items = await query
+                .OrderBy(b => b.Title)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return (items, total);
+        }
     }
 }

--- a/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
+++ b/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
@@ -651,5 +651,41 @@ namespace Enrich.UnitTests.Controllers
             // Assert
             Assert.That(result, Is.InstanceOf<ForbidResult>());
         }
+
+        [Test]
+        public async Task SaveCommunityBundle_ValidId_ReturnsOk()
+        {
+            // Arrange
+            var bundleId = 1;
+            _bundleServiceMock
+                .Setup(s => s.SaveCommunityBundleAsync(TestUserId, bundleId))
+                .ReturnsAsync(Result.Success());
+
+            // Act
+            var result = await _controller.SaveCommunityBundle(bundleId);
+
+            // Assert
+            var okResult = result as OkResult;
+            Assert.That(okResult, Is.Not.Null);
+            _bundleServiceMock.Verify(s => s.SaveCommunityBundleAsync(TestUserId, bundleId), Times.Once);
+        }
+
+        [Test]
+        public async Task SaveCommunityBundle_WhenServiceReturnsError_ReturnsBadRequest()
+        {
+            // Arrange
+            var bundleId = 1;
+            var errorMessage = "Collection not found or is not a valid community collection.";
+            _bundleServiceMock
+                .Setup(s => s.SaveCommunityBundleAsync(TestUserId, bundleId))
+                .ReturnsAsync(Result.Failure(errorMessage));
+
+            // Act
+            var result = await _controller.SaveCommunityBundle(bundleId);
+
+            // Assert
+            var badRequestResult = result as BadRequestObjectResult;
+            Assert.That(badRequestResult, Is.Not.Null);
+        }
     }
 }

--- a/Enrich/Enrich.UnitTests/Controllers/CollectionControllerTests.cs
+++ b/Enrich/Enrich.UnitTests/Controllers/CollectionControllerTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Security.Claims;
+using Enrich.BLL.DTOs;
+using Enrich.BLL.Interfaces;
+using Enrich.BLL.Settings;
+using Enrich.DAL.Entities;
+using Enrich.Web.Controllers;
+using Enrich.Web.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace Enrich.UnitTests.Controllers
+{
+    [TestFixture]
+    public class CollectionControllerTests
+    {
+        private Mock<ILogger<CollectionController>> _loggerMock;
+        private Mock<IBundleService> _bundleServiceMock;
+        private Mock<IOptions<PaginationSettings>> _paginationOptionsMock;
+        private CollectionController _controller;
+
+        [SetUp]
+        public void Setup()
+        {
+            _loggerMock = new Mock<ILogger<CollectionController>>();
+            _bundleServiceMock = new Mock<IBundleService>();
+            _paginationOptionsMock = new Mock<IOptions<PaginationSettings>>();
+
+            _paginationOptionsMock.Setup(x => x.Value).Returns(new PaginationSettings { DefaultSystemBundlesPageSize = 12 });
+
+            _controller = new CollectionController(
+                _loggerMock.Object,
+                _bundleServiceMock.Object,
+                _paginationOptionsMock.Object);
+
+            var claims = new[] { new Claim(ClaimTypes.NameIdentifier, "test-user-id") };
+            var identity = new ClaimsIdentity(claims, "mock");
+            var user = new ClaimsPrincipal(identity);
+
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _controller?.Dispose();
+        }
+
+        [Test]
+        public async Task Community_ReturnsViewResult_WithValidModel()
+        {
+            // Arrange
+            var model = new SystemBundlesIndexViewModel { SearchTerm = "test search" };
+            var pagedResult = new PagedResult<SystemBundleDTO>
+            {
+                Items = new List<SystemBundleDTO> { new SystemBundleDTO { Id = 1, Title = "Test Community Bundle" } },
+                TotalCount = 1,
+                Page = 1,
+                PageSize = 12
+            };
+            var categories = new List<Category> { new Category { Id = 1, Name = "Art" } };
+
+            _bundleServiceMock
+                .Setup(s => s.GetCommunityBundlesAsync("test search", null, null, null, null, 1, 12))
+                .ReturnsAsync(pagedResult);
+
+            _bundleServiceMock
+                .Setup(s => s.GetAllCategoriesAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var result = await _controller.Community(model, 1, 0);
+
+            // Assert
+            var viewResult = result as ViewResult;
+            Assert.That(viewResult, Is.Not.Null);
+
+            var viewModel = viewResult.Model as SystemBundlesIndexViewModel;
+            Assert.That(viewModel, Is.Not.Null);
+            Assert.That(viewModel.Bundles.TotalCount, Is.EqualTo(1));
+            Assert.That(viewModel.Categories.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Community_AjaxRequest_ReturnsPartialViewResult()
+        {
+            // Arrange
+            var model = new SystemBundlesIndexViewModel();
+            var pagedResult = new PagedResult<SystemBundleDTO>();
+
+            _bundleServiceMock
+                .Setup(s => s.GetCommunityBundlesAsync(null, null, null, null, null, 1, 12))
+                .ReturnsAsync(pagedResult);
+
+            _controller.ControllerContext.HttpContext.Request.Headers["X-Requested-With"] = "XMLHttpRequest";
+
+            // Act
+            var result = await _controller.Community(model, 1, 0);
+
+            // Assert
+            var partialViewResult = result as PartialViewResult;
+            Assert.That(partialViewResult, Is.Not.Null);
+            Assert.That(partialViewResult.ViewName, Is.EqualTo("_BundleListPartial"));
+        }
+    }
+}

--- a/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
@@ -250,5 +250,67 @@ namespace Enrich.UnitTests.Services
             Assert.That(result, Is.Null);
             _bundleRepositoryMock.Verify(r => r.GetBundleByIdWithDetailsAsync(bundleId), Times.Once);
         }
+
+        [Test]
+        public async Task GetCommunityBundlesAsync_ReturnsPagedResult()
+        {
+            // Arrange
+            var bundles = new List<Bundle>
+            {
+                new Bundle
+                {
+                    Id = 1,
+                    Title = "Community Bundle 1",
+                    Description = "Test Description",
+                    DifficultyLevels = ["B1", "B2"],
+                    Words = new List<Word> { new Word { Id = 1, Term = "Test" } },
+                    Categories = new List<Category> { new Category { Id = 1, Name = "Education" } }
+                }
+            };
+
+            _bundleRepositoryMock
+                .Setup(r => r.GetCommunityBundlesPageAsync(null, null, null, null, null, 1, 12))
+                .ReturnsAsync((bundles.AsEnumerable(), 1));
+
+            // Act
+            var result = await _bundleService.GetCommunityBundlesAsync(null, null, null, null, null, 1, 12);
+
+            // Assert
+            Assert.That(result.TotalCount, Is.EqualTo(1));
+            Assert.That(result.Items.Count(), Is.EqualTo(1));
+            Assert.That(result.Page, Is.EqualTo(1));
+            Assert.That(result.PageSize, Is.EqualTo(12));
+
+            var bundle = result.Items.First();
+            Assert.That(bundle.Id, Is.EqualTo(1));
+            Assert.That(bundle.Title, Is.EqualTo("Community Bundle 1"));
+            Assert.That(bundle.WordCount, Is.EqualTo(1));
+            Assert.That(bundle.Categories.Count, Is.EqualTo(1));
+
+            _bundleRepositoryMock.Verify(
+                r => r.GetCommunityBundlesPageAsync(null, null, null, null, null, 1, 12),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task GetCommunityBundlesAsync_WithInvalidPagination_DefaultsToValidValues()
+        {
+            // Arrange
+            _bundleRepositoryMock
+                .Setup(r => r.GetCommunityBundlesPageAsync(null, null, null, null, null, 1, 12))
+                .ReturnsAsync((new List<Bundle>().AsEnumerable(), 0));
+
+            // Act
+            // Передаємо page = 0 (невалідно) та pageSize = 0 (невалідно)
+            var result = await _bundleService.GetCommunityBundlesAsync(null, null, null, null, null, 0, 0);
+
+            // Assert
+            Assert.That(result.Page, Is.EqualTo(1)); // Має скинутися на 1
+            Assert.That(result.PageSize, Is.EqualTo(12)); // Має скинутися на дефолтні 12
+
+            _bundleRepositoryMock.Verify(
+                r => r.GetCommunityBundlesPageAsync(null, null, null, null, null, 1, 12),
+                Times.Once);
+        }
     }
 }

--- a/Enrich/Enrich.Web/Controllers/BundleController.cs
+++ b/Enrich/Enrich.Web/Controllers/BundleController.cs
@@ -270,6 +270,18 @@ namespace Enrich.Web.Controllers
         }
 
         [HttpPost]
+        public async Task<IActionResult> SaveCommunityBundle(int id)
+        {
+            var result = await bundleService.SaveCommunityBundleAsync(CurrentUserId, id);
+            if (!result.IsSuccess)
+            {
+                return BadRequest(new { message = result.ErrorMessage });
+            }
+
+            return Ok();
+        }
+
+        [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> SubmitForReview(int id)
         {

--- a/Enrich/Enrich.Web/Controllers/CollectionController.cs
+++ b/Enrich/Enrich.Web/Controllers/CollectionController.cs
@@ -44,5 +44,38 @@ namespace Enrich.Web.Controllers
 
             return View(model);
         }
+
+        [HttpGet]
+        public async Task<IActionResult> Community(SystemBundlesIndexViewModel model, int page = 1, int pageSize = 0)
+        {
+            if (pageSize <= 0)
+            {
+                pageSize = paginationOptions.Value.DefaultSystemBundlesPageSize;
+            }
+
+            model.PageSize = pageSize;
+
+            model.Bundles = await bundleService.GetCommunityBundlesAsync(
+                model.SearchTerm,
+                model.CategoryFilter,
+                model.LevelFilter,
+                model.MinWordCount,
+                model.MaxWordCount,
+                page,
+                pageSize);
+
+            model.Categories = await bundleService.GetAllCategoriesAsync();
+
+            logger.LogInformation(
+                "User {UserId} browsing community collections: page={Page}, results={Count}",
+                CurrentUserId, page, model.Bundles.Items.Count());
+
+            if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
+            {
+                return PartialView("_BundleListPartial", model);
+            }
+
+            return View(model);
+        }
     }
 }

--- a/Enrich/Enrich.Web/Views/Collection/Community.cshtml
+++ b/Enrich/Enrich.Web/Views/Collection/Community.cshtml
@@ -153,7 +153,7 @@
 
         async function toggleSaveBundle(bundleId, btnElement) {
             try {
-                const response = await fetch(`/Bundle/SaveSystemBundle?id=${bundleId}`, {
+                const response = await fetch(`/Bundle/SaveCommunityBundle?id=${bundleId}`, {
                     method: 'POST',
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',

--- a/Enrich/Enrich.Web/Views/Collection/Community.cshtml
+++ b/Enrich/Enrich.Web/Views/Collection/Community.cshtml
@@ -1,0 +1,188 @@
+@using Enrich.Web.ViewModels
+@model SystemBundlesIndexViewModel
+
+@{
+    ViewData["Title"] = "Community Collections";
+    Layout = "~/Views/Shared/_AppLayout.cshtml";
+}
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/collections.css" asp-append-version="true" />
+}
+
+<div class="container-fluid py-4">
+    <div class="row align-items-start">
+        <div class="col-lg-9">
+            <div class="d-flex flex-wrap gap-3 mb-4 align-items-center">
+                <div class="input-group flex-grow-1 search-box overflow-hidden" style="max-width: 600px;">
+                    <span class="input-group-text border-0 bg-transparent ps-3">
+                        <i class="bi bi-search text-muted"></i>
+                    </span>
+                    <input type="text" id="searchTerm" class="form-control border-0 bg-transparent p-2"
+                           placeholder="Search collections..." value="@Model.SearchTerm">
+                </div>
+                <button class="btn btn-action ms-auto">
+                    <i class="bi bi-sort-down me-2"></i> Sort by
+                </button>
+            </div>
+
+            <div id="bundles-list-container" data-page-size="@Model.PageSize">
+                <partial name="_BundleListPartial" model="Model" />
+            </div>
+        </div>
+
+        <div class="col-lg-3 ps-lg-4">
+            <div class="sidebar-panel" style="margin-top: 0;">
+                <h6 class="fw-bold mb-2" style="font-size:0.9rem;">Categories</h6>
+                <div class="border rounded-3 bg-white mb-2" style="height:200px; display:flex; flex-direction:column;">
+                    <div class="p-2 border-bottom">
+                        <input type="text" id="categorySearch" class="form-control border-0 bg-transparent"
+                               placeholder="Search categories..." style="font-size:0.85rem;">
+                    </div>
+                    <div class="p-2 overflow-y-scroll flex-grow-1">
+                        <ul class="list-unstyled mb-0" id="category-filters">
+                            @foreach (var cat in Model.Categories)
+                            {
+                                <li class="checkbox-item">
+                                    <input type="checkbox" class="form-check-input me-2 category-checkbox" id="cat-@cat.Id" value="@cat.Name" onchange="onFilterChange()">
+                                    <label class="form-check-label" for="cat-@cat.Id">@cat.Name</label>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="sidebar-divider"></div>
+
+                <h6 class="fw-bold mb-2" style="font-size:0.9rem;">Difficulty Level</h6>
+                <ul class="list-unstyled mb-0" id="level-filters">
+                    @foreach (var level in new[] { "C2", "C1", "B2", "B1", "A2", "A1" })
+                    {
+                        <li class="checkbox-item">
+                            <input type="checkbox" class="form-check-input me-2 level-checkbox" id="level-@level" value="@level" onchange="onFilterChange()">
+                            <label class="form-check-label" for="level-@level">@level</label>
+                        </li>
+                    }
+                </ul>
+
+                <div class="sidebar-divider"></div>
+
+                <h6 class="fw-bold mb-2" style="font-size:0.9rem;">Words Count</h6>
+                <div class="d-flex align-items-center justify-content-between">
+                    <input type="number" id="minWordCount" class="word-count-input" placeholder="Min" min="0" onchange="onFilterChange()">
+                    <span style="color: #adb5bd; font-size: 1.2rem; font-weight: 300;">—</span>
+                    <input type="number" id="maxWordCount" class="word-count-input" placeholder="Max" min="0" onchange="onFilterChange()">
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        let currentPage = 1;
+
+        function getFilters() {
+            const searchTerm = document.getElementById('searchTerm').value;
+            const category = Array.from(document.querySelectorAll('.category-checkbox:checked')).map(c => c.value).join(',');
+            const level = Array.from(document.querySelectorAll('.level-checkbox:checked')).map(c => c.value).join(',');
+            const minWordCount = document.getElementById('minWordCount').value;
+            const maxWordCount = document.getElementById('maxWordCount').value;
+
+            return { searchTerm, categoryFilter: category, levelFilter: level, minWordCount, maxWordCount };
+        }
+
+        async function loadBundles(page = 1) {
+            currentPage = page;
+            const filters = getFilters();
+            const params = new URLSearchParams({
+                page: page,
+                pageSize: parseInt(document.getElementById('bundles-list-container').dataset.pageSize, 10) || 12
+            });
+
+            if (filters.searchTerm) params.append('searchTerm', filters.searchTerm);
+            if (filters.categoryFilter) params.append('categoryFilter', filters.categoryFilter);
+            if (filters.levelFilter) params.append('levelFilter', filters.levelFilter);
+            if (filters.minWordCount) params.append('minWordCount', filters.minWordCount);
+            if (filters.maxWordCount) params.append('maxWordCount', filters.maxWordCount);
+
+            try {
+                const response = await fetch(`/Collection/Community?${params.toString()}`, {
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest'
+                    }
+                });
+
+                if (response.ok) {
+                    const html = await response.text();
+                    document.getElementById('bundles-list-container').innerHTML = html;
+                }
+            } catch (err) {
+                console.error("Failed to load collections", err);
+            }
+        }
+
+        function onFilterChange() {
+            loadBundles(1);
+        }
+
+        function changePage(page) {
+            loadBundles(page);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+
+        document.getElementById('searchTerm').addEventListener('input', debounce(() => {
+            onFilterChange();
+        }, 500));
+
+        function debounce(func, timeout = 300) {
+            let timer;
+            return (...args) => {
+                clearTimeout(timer);
+                timer = setTimeout(() => { func.apply(this, args); }, timeout);
+            };
+        }
+
+        document.getElementById('categorySearch').addEventListener('input', (e) => {
+            const q = e.target.value.trim().toLowerCase();
+            document.querySelectorAll('#category-filters li').forEach(li => {
+                const text = li.innerText.trim().toLowerCase();
+                li.style.display = q === '' || text.includes(q) ? '' : 'none';
+            });
+        });
+
+        async function toggleSaveBundle(bundleId, btnElement) {
+            try {
+                const response = await fetch(`/Bundle/SaveSystemBundle?id=${bundleId}`, {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'Content-Type': 'application/json'
+                    }
+                });
+
+                if (response.ok) {
+                    if (btnElement) {
+                        const icon = btnElement.querySelector('i');
+                        
+                        icon.classList.remove('bi-star');
+                        icon.classList.add('bi-star-fill');
+                        
+                        btnElement.classList.remove('text-secondary');
+                        btnElement.classList.add('text-warning'); 
+                        
+                        btnElement.title = "Saved";
+                        btnElement.disabled = true;
+                        btnElement.style.opacity = '1';
+                    }
+                } else {
+                    const error = await response.json();
+                    alert(error.message || 'Error saving the collection.');
+                }
+            } catch (err) {
+                console.error("Failed to save collection", err);
+                alert('A network error occurred.');
+            }
+        }
+    </script>
+}

--- a/Enrich/Enrich.Web/Views/Shared/_AppLayout.cshtml
+++ b/Enrich/Enrich.Web/Views/Shared/_AppLayout.cshtml
@@ -65,7 +65,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a asp-controller="Collection" asp-action="Index" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentController == "Collection" ? activeClass : inactiveClass)"
+                        <a asp-controller="Collection" asp-action="Index" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentController == "Collection" && currentAction == "Index" ? activeClass : inactiveClass)"
                            style="font-weight: 500; font-size: 0.95rem;">
                             <i class="bi bi-collection me-3 fs-6"></i>Collections
                         </a>
@@ -85,10 +85,10 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentAction == "Community" ? activeClass : inactiveClass)"
-                           style="font-weight: 500; font-size: 0.95rem;">
-                            <i class="bi bi-people me-3 fs-6"></i>Community
-                        </a>
+                        <a asp-controller="Collection" asp-action="Community" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentAction == "Community" ? activeClass : inactiveClass)"
+                             style="font-weight: 500; font-size: 0.95rem;">
+                               <i class="bi bi-people me-3 fs-6"></i>Community
+</a>
                     </li>
                     <li class="nav-item">
                         <a href="#" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentAction == "Generator" ? activeClass : inactiveClass)"


### PR DESCRIPTION
This PR implements the "Community Bundles" feature, allowing users to browse collections created and published by other users, as well as save them to their personal library.

**Resolves:** Closes #79, Closes #80

## Key Changes
* **Frontend:** * Created `Community.cshtml` view for displaying community bundles with search and filtering.
  * Updated the sidebar navigation (`_AppLayout.cshtml`) to correctly highlight the active tabs.
  * Updated the JavaScript fetch logic to call the correct `SaveCommunityBundle` endpoint.
* **Backend (Controllers):** * Added `Community` action in `CollectionController` to serve the page and handle AJAX pagination/filtering.
  * Added `SaveCommunityBundle` action in `BundleController`.
* **Backend (Services/DAL):** * Implemented `GetCommunityBundlesAsync` logic to fetch only `IsSystem = false` and `Status = Published` bundles.
  * Implemented `SaveCommunityBundleAsync` to allow importing community bundles.
* **Tests:** * Added comprehensive unit tests for `CollectionController`, `BundleController`, and `BundleService` to ensure 100% coverage of the new use cases.

## How to Test
1. Run the application and open the sidebar.
2. Ensure that "Collections" and "Community" tabs highlight correctly and independently.
3. *Note: To see items on the Community page, manually change at least one non-system bundle in the database to `Status = 2` (Published).*
4. Click the star icon on a community bundle and verify it successfully saves to the personal library.