### PR TITLE
feat: implement save generated bundle use case and update BundleService

### DIFF
--- a/Enrich/Enrich.BLL/DTOs/SaveGeneratedBundleDTO.cs
+++ b/Enrich/Enrich.BLL/DTOs/SaveGeneratedBundleDTO.cs
@@ -1,0 +1,15 @@
+namespace Enrich.BLL.DTOs
+{
+    public class SaveGeneratedBundleDTO
+    {
+        public string Title { get; set; } = null!;
+
+        public string? Description { get; set; }
+
+        public IEnumerable<int> WordIds { get; set; } = Array.Empty<int>();
+
+        public string[] DifficultyLevels { get; set; } = [];
+
+        public IEnumerable<string> CategoryNames { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
@@ -63,6 +63,8 @@ namespace Enrich.BLL.Interfaces
 
         Task<Result> SaveCommunityBundleAsync(string userId, int bundleId);
 
+        Task<Result> SaveGeneratedBundleAsync(string userId, SaveGeneratedBundleDTO dto);
+
         Task<Result> SubmitBundleForReviewAsync(string userId, int bundleId);
 
         Task<Result> ReviewBundleAsync(int bundleId, bool approve);

--- a/Enrich/Enrich.BLL/Services/BundleService.cs
+++ b/Enrich/Enrich.BLL/Services/BundleService.cs
@@ -27,7 +27,8 @@ namespace Enrich.BLL.Services
                 return "Bundle title cannot be empty.";
             }
 
-            var titleLower = dto.Title.Trim().ToLowerInvariant();
+            var trimmedTitle = dto.Title.Trim();
+            var titleLower = trimmedTitle.ToLowerInvariant();
 
             var duplicateExists = await bundleRepository.BundleTitleExistsForUserAsync(userId, titleLower);
 
@@ -45,7 +46,7 @@ namespace Enrich.BLL.Services
 
             var bundle = new Bundle
             {
-                Title = dto.Title.Trim(),
+                Title = trimmedTitle,
                 Description = dto.Description?.Trim(),
                 DifficultyLevels = dto.DifficultyLevels ?? [],
                 ImageUrl = dto.ImageUrl,
@@ -80,7 +81,7 @@ namespace Enrich.BLL.Services
                 }
 
                 logger.LogInformation(
-                    "Користувач {UserId} успішно створив новий бандл '{Title}' (ID: {BundleId}) зі статусом {Status}.",
+                    "User {UserId} successfully created a new bundle '{Title}' (ID: {BundleId}) with status {Status}.",
                     userId,
                     createdBundle.Title,
                     createdBundle.Id,
@@ -106,7 +107,7 @@ namespace Enrich.BLL.Services
 
             if (bundle == null)
             {
-                logger.LogWarning("Спроба отримати неіснуючий бандл з ID: {BundleId}.", bundleId);
+                logger.LogWarning("Attempting to get a non-existent bundle with ID: {BundleId}.", bundleId);
                 return null;
             }
 
@@ -115,14 +116,14 @@ namespace Enrich.BLL.Services
 
         public async Task<IEnumerable<BundleDTO>> GetUserBundlesAsync(string userId)
         {
-            logger.LogInformation("Отримання списку бандлів користувача {UserId}.", userId);
+            logger.LogInformation("Retrieving bundle list for user {UserId}.", userId);
 
             var bundles = await bundleRepository.GetUserBundlesAsync(userId);
 
             var bundleDTOs = bundles.Select(MapBundleToDTO).ToList();
 
             logger.LogInformation(
-                "Успішно отримано {Count} бандлів для користувача {UserId}.",
+                "Successfully retrieved {Count} bundles for user {UserId}.",
                 bundleDTOs.Count,
                 userId);
 
@@ -240,7 +241,7 @@ namespace Enrich.BLL.Services
              int page,
              int pageSize)
         {
-            logger.LogInformation("Отримання сторінки ком'юніті бандлів: сторінка={Page}, розмір={PageSize}", page, pageSize);
+            logger.LogInformation("Retrieving community bundles page: page={Page}, size={PageSize}", page, pageSize);
 
             if (page <= 0)
             {
@@ -290,7 +291,7 @@ namespace Enrich.BLL.Services
              int page,
              int pageSize)
         {
-            logger.LogInformation("Отримання сторінки бандлів на перевірці: сторінка={Page}, розмір={PageSize}", page, pageSize);
+            logger.LogInformation("Retrieving pending review bundles page: page={Page}, size={PageSize}", page, pageSize);
 
             if (page <= 0)
             {
@@ -689,6 +690,108 @@ namespace Enrich.BLL.Services
             {
                 logger.LogError(ex, "Error saving community bundle {BundleId} by user {UserId}.", bundleId, userId);
                 return "An error occurred while saving the collection.";
+            }
+        }
+
+        public async Task<Result> SaveGeneratedBundleAsync(string userId, SaveGeneratedBundleDTO dto)
+        {
+            if (dto == null)
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle with empty payload.", userId);
+                return "Invalid bundle data.";
+            }
+
+            if (string.IsNullOrWhiteSpace(dto.Title))
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle with an empty title.", userId);
+                return "Bundle title cannot be empty.";
+            }
+
+            var wordIds = dto.WordIds?
+                .Where(id => id > 0)
+                .Distinct()
+                .ToList() ?? new List<int>();
+
+            if (!wordIds.Any())
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle '{Title}' with no words.", userId, dto.Title);
+                return "Generated bundle has no words to save.";
+            }
+
+            var titleLower = dto.Title.Trim().ToLowerInvariant();
+            var duplicateExists = await bundleRepository.BundleTitleExistsForUserAsync(userId, titleLower);
+            if (duplicateExists)
+            {
+                logger.LogWarning("User {UserId} attempted to save a duplicate generated bundle '{Title}'.", userId, dto.Title);
+                return $"You already have a bundle named '{dto.Title}'.";
+            }
+
+            var difficultyLevels = dto.DifficultyLevels?
+                .Where(level => !string.IsNullOrWhiteSpace(level))
+                .Select(level => level.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? [];
+
+            var now = DateTime.UtcNow;
+            var bundle = new Bundle
+            {
+                Title = dto.Title.Trim(),
+                Description = dto.Description?.Trim(),
+                DifficultyLevels = difficultyLevels,
+                Status = BundleStatus.Draft,
+                IsSystem = false,
+                IsPublic = false,
+                OwnerId = userId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Words = new List<Word>(),
+                Categories = new List<Category>(),
+                Tags = new List<Tag>()
+            };
+
+            try
+            {
+                var createdBundle = await bundleRepository.CreateBundleAsync(bundle);
+
+                await bundleRepository.AddWordsToBundleAsync(createdBundle.Id, wordIds);
+
+                var categoryNames = dto.CategoryNames?
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Select(name => name.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList() ?? new List<string>();
+
+                if (categoryNames.Any())
+                {
+                    var categoryIds = new List<int>();
+                    foreach (var name in categoryNames)
+                    {
+                        var category = await categoryRepository.GetCategoryByNameAsync(name);
+                        if (category != null)
+                        {
+                            categoryIds.Add(category.Id);
+                        }
+                    }
+
+                    if (categoryIds.Any())
+                    {
+                        await bundleRepository.AddCategoriesToBundleAsync(createdBundle.Id, categoryIds.Distinct());
+                    }
+                }
+
+                logger.LogInformation(
+                    "User {UserId} saved generated bundle '{Title}' (ID: {BundleId}) with {WordCount} words.",
+                    userId,
+                    createdBundle.Title,
+                    createdBundle.Id,
+                    wordIds.Count);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error saving generated bundle '{Title}' by user {UserId}.", dto.Title, userId);
+                return "An error occurred while saving the generated bundle.";
             }
         }
 

--- a/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
+++ b/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json;
 using Enrich.BLL.Common;
 using Enrich.BLL.DTOs;
 using Enrich.BLL.Interfaces;
@@ -686,6 +687,60 @@ namespace Enrich.UnitTests.Controllers
         }
 
         [Test]
+        public async Task SaveGenerated_ValidRequest_ReturnsOk()
+        {
+            // Arrange
+            var model = new PreviewGeneratedViewModel
+            {
+                Title = "Generated Bundle",
+                Description = "Auto generated",
+                WordsJson = JsonSerializer.Serialize(new[] { new { Id = 1, Term = "Test", CategoryName = "General", DifficultyLevel = "A1" } })
+            };
+
+            _bundleServiceMock
+                .Setup(s => s.SaveGeneratedBundleAsync(TestUserId, It.IsAny<SaveGeneratedBundleDTO>()))
+                .ReturnsAsync(Result.Success());
+
+            // Act
+            var result = await _controller.SaveGenerated(model);
+
+            // Assert
+            var okResult = result as OkObjectResult;
+            Assert.That(okResult, Is.Not.Null);
+            _bundleServiceMock.Verify(
+                s => s.SaveGeneratedBundleAsync(
+                    TestUserId,
+                    It.Is<SaveGeneratedBundleDTO>(dto =>
+                        dto.Title == "Generated Bundle" &&
+                        dto.WordIds.Contains(1) &&
+                        dto.DifficultyLevels.Contains("A1") &&
+                        dto.CategoryNames.Contains("General"))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task SaveGenerated_WhenServiceReturnsError_ReturnsBadRequest()
+        {
+            // Arrange
+            var model = new PreviewGeneratedViewModel
+            {
+                Title = "Generated Bundle",
+                WordsJson = JsonSerializer.Serialize(new[] { new { Id = 1, Term = "Test" } })
+            };
+
+            _bundleServiceMock
+                .Setup(s => s.SaveGeneratedBundleAsync(TestUserId, It.IsAny<SaveGeneratedBundleDTO>()))
+                .ReturnsAsync(Result.Failure("Failed"));
+
+            // Act
+            var result = await _controller.SaveGenerated(model);
+
+            // Assert
+            var badRequestResult = result as BadRequestObjectResult;
+            Assert.That(badRequestResult, Is.Not.Null);
+        }
+
+        [Test]
         public void PreviewGenerated_WhenWordsJsonIsNullOrWhitespace_SetsToEmptyArrayAndReturnsView()
         {
             // Arrange
@@ -711,7 +766,7 @@ namespace Enrich.UnitTests.Controllers
         public void PreviewGenerated_WhenWordsJsonIsValid_ReturnsViewWithModel()
         {
             // Arrange
-            var json = "[{\"Term\":\"test\",\"Translation\":\"тест\"}]";
+            var json = JsonSerializer.Serialize(new[] { new { Term = "test", Translation = "тест" } });
             var model = new PreviewGeneratedViewModel
             {
                 Title = "Test Bundle",

--- a/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
@@ -487,5 +487,75 @@ namespace Enrich.UnitTests.Services
             Assert.That(result.ErrorMessage, Does.Contain("No words found"));
             _bundleRepositoryMock.Verify(r => r.CreateBundleAsync(It.IsAny<Bundle>()), Times.Never);
         }
+
+        [Test]
+        public async Task SaveGeneratedBundleAsync_DuplicateTitle_ReturnsError()
+        {
+            // Arrange
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = "Generated Bundle",
+                WordIds = new[] { 1 }
+            };
+
+            _bundleRepositoryMock
+                .Setup(r => r.BundleTitleExistsForUserAsync(TestUserId, "generated bundle"))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _bundleService.SaveGeneratedBundleAsync(TestUserId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("already have a bundle"));
+            _bundleRepositoryMock.Verify(r => r.CreateBundleAsync(It.IsAny<Bundle>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SaveGeneratedBundleAsync_ValidData_SavesBundleWithWordsAndCategories()
+        {
+            // Arrange
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = "Generated Bundle",
+                Description = "Auto generated bundle",
+                WordIds = new[] { 2, 5 },
+                DifficultyLevels = ["A1", "B1"],
+                CategoryNames = ["General", "Science"]
+            };
+
+            var createdBundle = new Bundle { Id = 101 };
+
+            _bundleRepositoryMock
+                .Setup(r => r.BundleTitleExistsForUserAsync(TestUserId, "generated bundle"))
+                .ReturnsAsync(false);
+
+            _bundleRepositoryMock
+                .Setup(r => r.CreateBundleAsync(It.IsAny<Bundle>()))
+                .ReturnsAsync(createdBundle);
+
+            _categoryRepositoryMock
+                .Setup(r => r.GetCategoryByNameAsync("General"))
+                .ReturnsAsync(new Category { Id = 7, Name = "General" });
+            _categoryRepositoryMock
+                .Setup(r => r.GetCategoryByNameAsync("Science"))
+                .ReturnsAsync(new Category { Id = 8, Name = "Science" });
+
+            // Act
+            var result = await _bundleService.SaveGeneratedBundleAsync(TestUserId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            _bundleRepositoryMock.Verify(
+                r => r.AddWordsToBundleAsync(
+                    createdBundle.Id,
+                    It.Is<IEnumerable<int>>(ids => ids.Contains(2) && ids.Contains(5))),
+                Times.Once);
+            _bundleRepositoryMock.Verify(
+                r => r.AddCategoriesToBundleAsync(
+                    createdBundle.Id,
+                    It.Is<IEnumerable<int>>(ids => ids.Contains(7) && ids.Contains(8))),
+                Times.Once);
+        }
     }
 }

--- a/Enrich/Enrich.Web/Controllers/BundleController.cs
+++ b/Enrich/Enrich.Web/Controllers/BundleController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Enrich.BLL.DTOs;
 using Enrich.BLL.Interfaces;
 using Enrich.BLL.Settings;
@@ -278,6 +279,62 @@ namespace Enrich.Web.Controllers
             }
 
             return Ok();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> SaveGenerated([FromBody] PreviewGeneratedViewModel model)
+        {
+            if (model == null)
+            {
+                logger.LogWarning("User {UserId} submitted an empty generated bundle save request.", CurrentUserId);
+                return BadRequest(new { message = "Invalid data." });
+            }
+
+            List<SystemWordDTO> words;
+            try
+            {
+                words = model.Words;
+            }
+            catch (JsonException ex)
+            {
+                logger.LogWarning(ex, "User {UserId} submitted invalid generated bundle words payload.", CurrentUserId);
+                return BadRequest(new { message = "Invalid words data." });
+            }
+
+            var wordIds = words.Select(w => w.Id).Where(id => id > 0).Distinct().ToList();
+            if (!wordIds.Any())
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle without words.", CurrentUserId);
+                return BadRequest(new { message = "Generated bundle has no words to save." });
+            }
+
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = model.Title?.Trim() ?? string.Empty,
+                Description = model.Description?.Trim(),
+                WordIds = wordIds,
+                DifficultyLevels = words
+                    .Where(w => !string.IsNullOrWhiteSpace(w.DifficultyLevel))
+                    .Select(w => w.DifficultyLevel!.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                CategoryNames = words
+                    .Select(w => w.CategoryName?.Trim())
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Select(name => name!)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray()
+            };
+
+            var result = await bundleService.SaveGeneratedBundleAsync(CurrentUserId, dto);
+            if (!result.IsSuccess)
+            {
+                return BadRequest(new { message = result.ErrorMessage });
+            }
+
+            logger.LogInformation("User {UserId} saved generated bundle '{Title}'.", CurrentUserId, dto.Title);
+            return Ok(new { message = "Collection saved.", redirectUrl = Url?.Action("Index", "Bundle") });
         }
 
         [HttpPost]

--- a/Enrich/Enrich.Web/Views/Bundle/PreviewGenerated.cshtml
+++ b/Enrich/Enrich.Web/Views/Bundle/PreviewGenerated.cshtml
@@ -180,8 +180,13 @@
                     </div>
                 </div>
 
+                <input type="hidden" id="generatedTitle" value="@Model.Title" />
+                <input type="hidden" id="generatedDescription" value="@Model.Description" />
+                <input type="hidden" id="generatedWordsJson" value="@Model.WordsJson" />
+                @Html.AntiForgeryToken()
+
                 <div class="d-flex gap-2 mt-auto flex-column flex-sm-row">
-                    <button class="btn btn-action-success rounded-4 w-100 justify-content-center">
+                    <button id="btnSaveGenerated" type="button" class="btn btn-action-success rounded-4 w-100 justify-content-center">
                         <i class="bi bi-plus-circle me-2"></i> Add to My Collections
                     </button>
                     <button class="btn btn-action-outline-success rounded-4 w-100 justify-content-center">
@@ -262,3 +267,61 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script>
+        document.getElementById('btnSaveGenerated').addEventListener('click', async () => {
+            const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+            if (!token) {
+                showToast('Verification token missing.', 'danger');
+                return;
+            }
+
+            const payload = {
+                title: document.getElementById('generatedTitle').value,
+                description: document.getElementById('generatedDescription').value,
+                wordsJson: document.getElementById('generatedWordsJson').value
+            };
+
+            const btn = document.getElementById('btnSaveGenerated');
+            const originalText = btn.innerText;
+            btn.disabled = true;
+            btn.innerText = 'Saving...';
+
+            try {
+                const response = await fetch('@Url.Action("SaveGenerated", "Bundle")', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': token
+                    },
+                    body: JSON.stringify(payload)
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    showToast(data.message || 'Collection saved.', 'success');
+                    if (data.redirectUrl) {
+                        window.location.href = data.redirectUrl;
+                        return;
+                    }
+                } else {
+                    let errorMessage = 'Failed to save the collection.';
+                    try {
+                        const error = await response.json();
+                        errorMessage = error.message || errorMessage;
+                    } catch (err) {
+                        console.error(err);
+                    }
+                    showToast(errorMessage, 'danger');
+                }
+            } catch (err) {
+                console.error(err);
+                showToast('An unexpected error occurred.', 'danger');
+            } finally {
+                btn.disabled = false;
+                btn.innerText = originalText;
+            }
+        });
+    </script>
+}


### PR DESCRIPTION
This PR introduces the functionality to persist generated word bundles into the database. It bridges the gap between the generation logic and the storage layer, ensuring that users can save their results for future learning.

Key Changes

Domain Logic: Implemented SaveGeneratedBundleUseCase within the BLL to handle business rules during the saving process.

Service Layer: Updated BundleService and its interface IBundleService to include methods for processing and storing bundle DTOs.

Data Transfer: Added SaveGeneratedBundleDTO to decouple the web layer from the domain models.

Web Integration: Updated BundleController and the PreviewGenerated view to trigger the save action.

Quality Assurance: Added unit tests in BundleControllerTests and BundleServiceTests to verify the persistence workflow and edge cases.
Closes #94