### PR TITLE
Implement "Save Word During Study Session" use case #110

### DIFF
--- a/Enrich/Enrich.BLL/DTOs/QuizSetupDTO.cs
+++ b/Enrich/Enrich.BLL/DTOs/QuizSetupDTO.cs
@@ -1,0 +1,15 @@
+namespace Enrich.BLL.DTOs
+{
+    public class QuizSetupDTO
+    {
+        public string? Category { get; set; }
+
+        public string? PartOfSpeech { get; set; }
+
+        public int? MinDifficulty { get; set; }
+
+        public int? MaxDifficulty { get; set; }
+
+        public int WordCount { get; set; } = 10;
+    }
+}

--- a/Enrich/Enrich.BLL/DTOs/SaveGeneratedBundleDTO.cs
+++ b/Enrich/Enrich.BLL/DTOs/SaveGeneratedBundleDTO.cs
@@ -1,0 +1,15 @@
+namespace Enrich.BLL.DTOs
+{
+    public class SaveGeneratedBundleDTO
+    {
+        public string Title { get; set; } = null!;
+
+        public string? Description { get; set; }
+
+        public IEnumerable<int> WordIds { get; set; } = Array.Empty<int>();
+
+        public string[] DifficultyLevels { get; set; } = [];
+
+        public IEnumerable<string> CategoryNames { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Enrich/Enrich.BLL/DTOs/SaveWordRequest.cs
+++ b/Enrich/Enrich.BLL/DTOs/SaveWordRequest.cs
@@ -1,0 +1,7 @@
+namespace Enrich.BLL.DTOs
+{
+    public class SaveWordRequest
+    {
+        public int WordId { get; set; }
+    }
+}

--- a/Enrich/Enrich.BLL/DependencyInjection.cs
+++ b/Enrich/Enrich.BLL/DependencyInjection.cs
@@ -24,6 +24,7 @@ namespace Enrich.BLL
             services.AddScoped<IBundleService, BundleService>();
             services.AddScoped<IStudySessionService, StudySessionService>();
             services.AddScoped<ICategoryService, CategoryService>();
+            services.AddScoped<IQuizService, QuizService>();
 
             return services;
         }

--- a/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IBundleService.cs
@@ -63,6 +63,8 @@ namespace Enrich.BLL.Interfaces
 
         Task<Result> SaveCommunityBundleAsync(string userId, int bundleId);
 
+        Task<Result> SaveGeneratedBundleAsync(string userId, SaveGeneratedBundleDTO dto);
+
         Task<Result> SubmitBundleForReviewAsync(string userId, int bundleId);
 
         Task<Result> ReviewBundleAsync(int bundleId, bool approve);
@@ -70,5 +72,9 @@ namespace Enrich.BLL.Interfaces
         Task<BundleDTO?> GetBundleWithWordsAsync(int bundleId);
 
         Task<Result<GeneratedBundleResultDTO>> GenerateBundleAsync(string userId, GenerateBundleDTO dto);
+
+        Task<Result> CreateSystemBundleAsync(CreateBundleDTO dto);
+
+        Task<Result> UpdateSystemBundleAsync(int bundleId, CreateBundleDTO dto);
     }
 }

--- a/Enrich/Enrich.BLL/Interfaces/IQuizService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IQuizService.cs
@@ -1,0 +1,14 @@
+using Enrich.BLL.Common;
+using Enrich.BLL.DTOs;
+
+namespace Enrich.BLL.Interfaces
+{
+    public interface IQuizService
+    {
+        Task<Result<StudySessionDTO>> StartCustomQuizAsync(string userId, QuizSetupDTO setup);
+
+        Task<Result<IEnumerable<string>>> GetAvailableCategoriesAsync(string userId);
+
+        Task<Result<IEnumerable<string>>> GetAvailablePartsOfSpeechAsync(string userId);
+    }
+}

--- a/Enrich/Enrich.BLL/Interfaces/IWordService.cs
+++ b/Enrich/Enrich.BLL/Interfaces/IWordService.cs
@@ -18,6 +18,8 @@ namespace Enrich.BLL.Interfaces
 
         Task<Result> SaveSystemWordAsync(string userId, int wordId);
 
+        Task<Result> SaveWordToLibraryAsync(string userId, int wordId);
+
         Task<IEnumerable<Category>> GetAllCategoriesAsync();
 
         Task<IEnumerable<Category>> GetCategoriesByIdsAsync(IEnumerable<int> ids);

--- a/Enrich/Enrich.BLL/Services/BundleService.cs
+++ b/Enrich/Enrich.BLL/Services/BundleService.cs
@@ -31,7 +31,8 @@ namespace Enrich.BLL.Services
                 return "Bundle title cannot be empty.";
             }
 
-            var titleLower = dto.Title.Trim().ToLowerInvariant();
+            var trimmedTitle = dto.Title.Trim();
+            var titleLower = trimmedTitle.ToLowerInvariant();
 
             var duplicateExists = await bundleRepository.BundleTitleExistsForUserAsync(userId, titleLower);
 
@@ -49,7 +50,7 @@ namespace Enrich.BLL.Services
 
             var bundle = new Bundle
             {
-                Title = dto.Title.Trim(),
+                Title = trimmedTitle,
                 Description = dto.Description?.Trim(),
                 DifficultyLevels = dto.DifficultyLevels ?? [],
                 ImageUrl = dto.ImageUrl,
@@ -84,7 +85,7 @@ namespace Enrich.BLL.Services
                 }
 
                 logger.LogInformation(
-                    "Користувач {UserId} успішно створив новий бандл '{Title}' (ID: {BundleId}) зі статусом {Status}.",
+                    "User {UserId} successfully created a new bundle '{Title}' (ID: {BundleId}) with status {Status}.",
                     userId,
                     createdBundle.Title,
                     createdBundle.Id,
@@ -110,7 +111,7 @@ namespace Enrich.BLL.Services
 
             if (bundle == null)
             {
-                logger.LogWarning("Спроба отримати неіснуючий бандл з ID: {BundleId}.", bundleId);
+                logger.LogWarning("Attempting to get a non-existent bundle with ID: {BundleId}.", bundleId);
                 return null;
             }
 
@@ -119,14 +120,14 @@ namespace Enrich.BLL.Services
 
         public async Task<IEnumerable<BundleDTO>> GetUserBundlesAsync(string userId)
         {
-            logger.LogInformation("Отримання списку бандлів користувача {UserId}.", userId);
+            logger.LogInformation("Retrieving bundle list for user {UserId}.", userId);
 
             var bundles = await bundleRepository.GetUserBundlesAsync(userId);
 
             var bundleDTOs = bundles.Select(MapBundleToDTO).ToList();
 
             logger.LogInformation(
-                "Успішно отримано {Count} бандлів для користувача {UserId}.",
+                "Successfully retrieved {Count} bundles for user {UserId}.",
                 bundleDTOs.Count,
                 userId);
 
@@ -244,7 +245,7 @@ namespace Enrich.BLL.Services
              int page,
              int pageSize)
         {
-            logger.LogInformation("Отримання сторінки ком'юніті бандлів: сторінка={Page}, розмір={PageSize}", page, pageSize);
+            logger.LogInformation("Retrieving community bundles page: page={Page}, size={PageSize}", page, pageSize);
 
             if (page <= 0)
             {
@@ -294,7 +295,7 @@ namespace Enrich.BLL.Services
              int page,
              int pageSize)
         {
-            logger.LogInformation("Отримання сторінки бандлів на перевірці: сторінка={Page}, розмір={PageSize}", page, pageSize);
+            logger.LogInformation("Retrieving pending review bundles page: page={Page}, size={PageSize}", page, pageSize);
 
             if (page <= 0)
             {
@@ -700,6 +701,108 @@ namespace Enrich.BLL.Services
             }
         }
 
+        public async Task<Result> SaveGeneratedBundleAsync(string userId, SaveGeneratedBundleDTO dto)
+        {
+            if (dto == null)
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle with empty payload.", userId);
+                return "Invalid bundle data.";
+            }
+
+            if (string.IsNullOrWhiteSpace(dto.Title))
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle with an empty title.", userId);
+                return "Bundle title cannot be empty.";
+            }
+
+            var wordIds = dto.WordIds?
+                .Where(id => id > 0)
+                .Distinct()
+                .ToList() ?? new List<int>();
+
+            if (!wordIds.Any())
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle '{Title}' with no words.", userId, dto.Title);
+                return "Generated bundle has no words to save.";
+            }
+
+            var titleLower = dto.Title.Trim().ToLowerInvariant();
+            var duplicateExists = await bundleRepository.BundleTitleExistsForUserAsync(userId, titleLower);
+            if (duplicateExists)
+            {
+                logger.LogWarning("User {UserId} attempted to save a duplicate generated bundle '{Title}'.", userId, dto.Title);
+                return $"You already have a bundle named '{dto.Title}'.";
+            }
+
+            var difficultyLevels = dto.DifficultyLevels?
+                .Where(level => !string.IsNullOrWhiteSpace(level))
+                .Select(level => level.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? [];
+
+            var now = DateTime.UtcNow;
+            var bundle = new Bundle
+            {
+                Title = dto.Title.Trim(),
+                Description = dto.Description?.Trim(),
+                DifficultyLevels = difficultyLevels,
+                Status = BundleStatus.Draft,
+                IsSystem = false,
+                IsPublic = false,
+                OwnerId = userId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Words = new List<Word>(),
+                Categories = new List<Category>(),
+                Tags = new List<Tag>()
+            };
+
+            try
+            {
+                var createdBundle = await bundleRepository.CreateBundleAsync(bundle);
+
+                await bundleRepository.AddWordsToBundleAsync(createdBundle.Id, wordIds);
+
+                var categoryNames = dto.CategoryNames?
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Select(name => name.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList() ?? new List<string>();
+
+                if (categoryNames.Any())
+                {
+                    var categoryIds = new List<int>();
+                    foreach (var name in categoryNames)
+                    {
+                        var category = await categoryRepository.GetCategoryByNameAsync(name);
+                        if (category != null)
+                        {
+                            categoryIds.Add(category.Id);
+                        }
+                    }
+
+                    if (categoryIds.Any())
+                    {
+                        await bundleRepository.AddCategoriesToBundleAsync(createdBundle.Id, categoryIds.Distinct());
+                    }
+                }
+
+                logger.LogInformation(
+                    "User {UserId} saved generated bundle '{Title}' (ID: {BundleId}) with {WordCount} words.",
+                    userId,
+                    createdBundle.Title,
+                    createdBundle.Id,
+                    wordIds.Count);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error saving generated bundle '{Title}' by user {UserId}.", dto.Title, userId);
+                return "An error occurred while saving the generated bundle.";
+            }
+        }
+
         public async Task<Result> SubmitBundleForReviewAsync(string userId, int bundleId)
         {
             var bundle = await bundleRepository.GetBundleByIdAsync(bundleId);
@@ -828,6 +931,88 @@ namespace Enrich.BLL.Services
             logger.LogInformation("Temporary bundle '{Title}' successfully generated ({WordCount} words).", dto.Title, result.Words.Count);
 
             return result;
+        }
+
+        public async Task<Result> CreateSystemBundleAsync(CreateBundleDTO dto)
+        {
+            if (string.IsNullOrWhiteSpace(dto.Title))
+            {
+                logger.LogWarning("Attempt to create a system bundle with an empty title.");
+                return "Bundle title cannot be empty.";
+            }
+
+            var now = DateTime.UtcNow;
+
+            var bundle = new Bundle
+            {
+                Title = dto.Title.Trim(),
+                Description = dto.Description?.Trim(),
+                DifficultyLevels = dto.DifficultyLevels ?? [],
+                ImageUrl = dto.ImageUrl,
+                Status = BundleStatus.Published, // Системні бандли відразу опубліковані
+                IsSystem = true,                 // Головна відмінність!
+                IsPublic = true,
+                OwnerId = "SYSTEM",              // Власник - система
+                CreatedAt = now,
+                UpdatedAt = now,
+                Words = new List<Word>(),
+                Categories = new List<Category>(),
+                Tags = new List<Tag>()
+            };
+
+            try
+            {
+                var createdBundle = await bundleRepository.CreateBundleAsync(bundle);
+
+                if (dto.WordIds != null && dto.WordIds.Any())
+                {
+                    await bundleRepository.AddWordsToBundleAsync(createdBundle.Id, dto.WordIds);
+                }
+
+                if (dto.CategoryIds != null && dto.CategoryIds.Any())
+                {
+                    await bundleRepository.AddCategoriesToBundleAsync(createdBundle.Id, dto.CategoryIds);
+                }
+
+                logger.LogInformation("System bundle '{Title}' (ID: {BundleId}) successfully created.", createdBundle.Title, createdBundle.Id);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error creating system bundle '{Title}'.", dto.Title);
+                return "An error occurred while creating the system bundle.";
+            }
+        }
+
+        public async Task<Result> UpdateSystemBundleAsync(int bundleId, CreateBundleDTO dto)
+        {
+            var bundle = await bundleRepository.GetBundleByIdAsync(bundleId);
+
+            if (bundle == null || !bundle.IsSystem)
+            {
+                logger.LogWarning("Attempted to update non-existent or non-system bundle {BundleId}.", bundleId);
+                return "System bundle not found.";
+            }
+
+            bundle.Title = dto.Title.Trim();
+            bundle.Description = dto.Description?.Trim();
+            bundle.DifficultyLevels = dto.DifficultyLevels ?? [];
+            bundle.ImageUrl = dto.ImageUrl;
+            bundle.UpdatedAt = DateTime.UtcNow;
+
+            try
+            {
+                await bundleRepository.UpdateBundleAsync(bundle);
+                await bundleRepository.SyncBundleRelationsAsync(bundle.Id, dto.WordIds, dto.CategoryIds);
+
+                logger.LogInformation("System bundle {BundleId} successfully updated.", bundleId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error updating system bundle {BundleId}.", bundleId);
+                return "An error occurred while updating the system bundle.";
+            }
         }
     }
 }

--- a/Enrich/Enrich.BLL/Services/QuizService.cs
+++ b/Enrich/Enrich.BLL/Services/QuizService.cs
@@ -1,0 +1,137 @@
+using Enrich.BLL.Common;
+using Enrich.BLL.DTOs;
+using Enrich.BLL.Interfaces;
+using Enrich.DAL.Entities;
+using Enrich.DAL.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Enrich.BLL.Services
+{
+    public class QuizService(
+        IWordRepository wordRepository,
+        ITrainingSessionRepository trainingSessionRepository,
+        ILogger<QuizService> logger) : IQuizService
+    {
+        public async Task<Result<StudySessionDTO>> StartCustomQuizAsync(string userId, QuizSetupDTO setup)
+        {
+            try
+            {
+                var words = await wordRepository.GetRandomPersonalWordsByCriteriaAsync(
+                    userId,
+                    setup.Category,
+                    setup.PartOfSpeech,
+                    setup.MinDifficulty != null ? GetLevelFromIndex(setup.MinDifficulty.Value) : null,
+                    setup.MaxDifficulty != null ? GetLevelFromIndex(setup.MaxDifficulty.Value) : null,
+                    setup.WordCount);
+
+                var wordList = words.ToList();
+
+                if (!wordList.Any())
+                {
+                    logger.LogWarning("User {UserId} tried to start a quiz, but no words were found matching the criteria.", userId);
+                    return Result<StudySessionDTO>.Failure("No words found matching the specified criteria.");
+                }
+
+                var session = new TrainingSession
+                {
+                    UserId = userId,
+                    BundleId = null,
+                    StartedAt = DateTime.UtcNow,
+                    TotalCards = wordList.Count,
+                    KnownCount = 0,
+                    UnknownCount = 0
+                };
+
+                var createdSession = await trainingSessionRepository.CreateSessionAsync(session);
+
+                var cards = wordList.Select(w => new StudyCardDTO
+                {
+                    WordId = w.Id,
+                    Term = w.Term,
+                    Translation = w.Translation,
+                    Transcription = w.Transcription,
+                    Meaning = w.Meaning,
+                    PartOfSpeech = w.PartOfSpeech,
+                    Example = w.Example,
+                    ImageUrl = w.ImageUrl,
+                    DifficultyLevel = w.DifficultyLevel
+                }).ToList();
+
+                var dto = new StudySessionDTO
+                {
+                    SessionId = createdSession.Id,
+                    BundleId = 0,
+                    BundleTitle = "Custom Quiz",
+                    Cards = cards,
+                    TotalCards = cards.Count,
+                    StartedAt = createdSession.StartedAt
+                };
+
+                logger.LogInformation(
+                    "User {UserId} started a custom quiz {SessionId} ({CardCount} cards).",
+                    userId,
+                    createdSession.Id,
+                    cards.Count);
+
+                return Result<StudySessionDTO>.Success(dto);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error creating custom quiz for user {UserId}.", userId);
+                return Result<StudySessionDTO>.Failure("Error creating quiz.");
+            }
+        }
+
+        public async Task<Result<IEnumerable<string>>> GetAvailableCategoriesAsync(string userId)
+        {
+            try
+            {
+                var personalWords = await wordRepository.GetPersonalWordsWithDetailsAsync(userId);
+                var categories = personalWords
+                    .SelectMany(uw => uw.Word.Categories)
+                    .Select(c => c.Name)
+                    .Distinct()
+                    .OrderBy(c => c);
+
+                return Result<IEnumerable<string>>.Success(categories);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error retrieving categories for user {UserId}.", userId);
+                return Result<IEnumerable<string>>.Failure("Error retrieving categories.");
+            }
+        }
+
+        public async Task<Result<IEnumerable<string>>> GetAvailablePartsOfSpeechAsync(string userId)
+        {
+            try
+            {
+                var personalWords = await wordRepository.GetPersonalWordsWithDetailsAsync(userId);
+                var parts = personalWords
+                    .Select(uw => uw.Word.PartOfSpeech)
+                    .Where(p => !string.IsNullOrEmpty(p))
+                    .Cast<string>()
+                    .Distinct()
+                    .OrderBy(p => p);
+
+                return Result<IEnumerable<string>>.Success(parts);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error retrieving parts of speech for user {UserId}.", userId);
+                return Result<IEnumerable<string>>.Failure("Error retrieving parts of speech.");
+            }
+        }
+
+        private static string GetLevelFromIndex(int index)
+        {
+            var levels = new[] { "A1", "A2", "B1", "B2", "C1", "C2" };
+            if (index < 0 || index >= levels.Length)
+            {
+                return levels[0];
+            }
+
+            return levels[index];
+        }
+    }
+}

--- a/Enrich/Enrich.BLL/Services/StudySessionService.cs
+++ b/Enrich/Enrich.BLL/Services/StudySessionService.cs
@@ -100,36 +100,36 @@ namespace Enrich.BLL.Services
 
                 if (session == null)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував подати відповідь для неіснуючої сесії {SessionId}.", userId, dto.SessionId);
-                    return Result<StudyProgressDTO>.Failure("Сесія не знайдена.");
+                    logger.LogWarning("User {UserId} tried to submit an answer for a non-existent session {SessionId}.", userId, dto.SessionId);
+                    return Result<StudyProgressDTO>.Failure("Session not found.");
                 }
 
                 if (session.UserId != userId)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував подати відповідь для сесії іншого користувача {SessionId}.", userId, dto.SessionId);
-                    return Result<StudyProgressDTO>.Failure("Доступ заборонено.");
+                    logger.LogWarning("User {UserId} tried to submit an answer for another user's session {SessionId}.", userId, dto.SessionId);
+                    return Result<StudyProgressDTO>.Failure("Access denied.");
                 }
 
                 if (session.FinishedAt.HasValue)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував подати відповідь для завершеної сесії {SessionId}.", userId, dto.SessionId);
-                    return Result<StudyProgressDTO>.Failure("Сесія вже завершена.");
+                    logger.LogWarning("User {UserId} tried to submit an answer for a finished session {SessionId}.", userId, dto.SessionId);
+                    return Result<StudyProgressDTO>.Failure("Session is already finished.");
                 }
 
                 var existingResult = await trainingSessionRepository.GetSessionResultAsync(dto.SessionId, dto.WordId);
 
                 if (existingResult != null)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував подати дублікат відповіді для слова {WordId} в сесії {SessionId}.", userId, dto.WordId, dto.SessionId);
-                    return Result<StudyProgressDTO>.Failure("Відповідь для цього слова вже подана.");
+                    logger.LogWarning("User {UserId} tried to submit a duplicate answer for word {WordId} in session {SessionId}.", userId, dto.WordId, dto.SessionId);
+                    return Result<StudyProgressDTO>.Failure("Answer for this word has already been submitted.");
                 }
 
                 var word = await wordRepository.GetWordAsync(dto.WordId);
 
                 if (word == null)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував подати відповідь для неіснуючого слова {WordId}.", userId, dto.WordId);
-                    return Result<StudyProgressDTO>.Failure("Слово не знайдено.");
+                    logger.LogWarning("User {UserId} tried to submit an answer for a non-existent word {WordId}.", userId, dto.WordId);
+                    return Result<StudyProgressDTO>.Failure("Word not found.");
                 }
 
                 int pointsAwarded = dto.IsKnown ? PointsForKnown : PointsForUnknown;
@@ -180,9 +180,9 @@ namespace Enrich.BLL.Services
                 await trainingSessionRepository.UpdateSessionAsync(session);
 
                 logger.LogInformation(
-                    "Користувач {UserId} подав відповідь '{Answer}' для слова {WordId} в сесії {SessionId}. Отримано балів: {Points}.",
+                    "User {UserId} submitted answer '{Answer}' for word {WordId} in session {SessionId}. Points awarded: {Points}.",
                     userId,
-                    dto.IsKnown ? "знав" : "не знав",
+                    dto.IsKnown ? "known" : "unknown",
                     dto.WordId,
                     dto.SessionId,
                     pointsAwarded);
@@ -202,11 +202,11 @@ namespace Enrich.BLL.Services
             {
                 logger.LogError(
                     ex,
-                    "Помилка при подачі відповіді користувачем {UserId} для сесії {SessionId}.",
+                    "Error submitting answer by user {UserId} for session {SessionId}.",
                     userId,
                     dto.SessionId);
 
-                return Result<StudyProgressDTO>.Failure("Помилка при обробці відповіді.");
+                return Result<StudyProgressDTO>.Failure("Error processing answer.");
             }
         }
 
@@ -218,21 +218,21 @@ namespace Enrich.BLL.Services
 
                 if (session == null)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував завершити неіснуючу сесію {SessionId}.", userId, sessionId);
-                    return Result.Failure("Сесія не знайдена.");
+                    logger.LogWarning("User {UserId} tried to finish a non-existent session {SessionId}.", userId, sessionId);
+                    return Result.Failure("Session not found.");
                 }
 
                 if (session.UserId != userId)
                 {
-                    logger.LogWarning("Користувач {UserId} спробував завершити сесію іншого користувача {SessionId}.", userId, sessionId);
-                    return Result.Failure("Доступ заборонено.");
+                    logger.LogWarning("User {UserId} tried to finish another user's session {SessionId}.", userId, sessionId);
+                    return Result.Failure("Access denied.");
                 }
 
                 session.FinishedAt = DateTime.UtcNow;
                 await trainingSessionRepository.UpdateSessionAsync(session);
 
                 logger.LogInformation(
-                    "Користувач {UserId} завершив сесію {SessionId}. Результат: {Known} знав, {Unknown} не знав з {Total} карток.",
+                    "User {UserId} finished session {SessionId}. Result: {Known} known, {Unknown} unknown out of {Total} cards.",
                     userId,
                     sessionId,
                     session.KnownCount,

--- a/Enrich/Enrich.BLL/Services/WordService.cs
+++ b/Enrich/Enrich.BLL/Services/WordService.cs
@@ -255,6 +255,42 @@ namespace Enrich.BLL.Services
             return true;
         }
 
+        public async Task<Result> SaveWordToLibraryAsync(string userId, int wordId)
+        {
+            if (wordId <= 0)
+            {
+                logger.LogWarning("User {UserId} submitted an invalid word id {WordId} for saving.", userId, wordId);
+                return "Word ID must be greater than zero.";
+            }
+
+            var word = await wordRepository.GetWordAsync(wordId);
+            if (word == null)
+            {
+                logger.LogWarning("User {UserId} attempted to save a missing word {WordId}.", userId, wordId);
+                return "Word not found.";
+            }
+
+            var alreadySaved = await wordRepository.UserHasWordAsync(userId, wordId);
+            if (alreadySaved)
+            {
+                logger.LogInformation("User {UserId} attempted to save a duplicate word {WordId}.", userId, wordId);
+                return "You have already saved this word.";
+            }
+
+            var userWord = new UserWord
+            {
+                UserId = userId,
+                WordId = wordId,
+                SavedAt = DateTime.UtcNow
+            };
+
+            await wordRepository.SaveUserWordAsync(userWord);
+
+            logger.LogInformation("User {UserId} saved word {WordId} to their library.", userId, wordId);
+
+            return true;
+        }
+
         public async Task<IEnumerable<Category>> GetAllCategoriesAsync()
         {
             return await cache.GetOrCreateAsync(CacheKeys.AllCategories, async entry =>

--- a/Enrich/Enrich.DAL/Data/Configurations/TrainingSessionConfiguration.cs
+++ b/Enrich/Enrich.DAL/Data/Configurations/TrainingSessionConfiguration.cs
@@ -26,7 +26,8 @@ namespace Enrich.DAL.Data.Configurations
             _ = builder.HasOne(ts => ts.Bundle)
                 .WithMany(b => b.TrainingSessions)
                 .HasForeignKey(ts => ts.BundleId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.SetNull);
         }
     }
 }

--- a/Enrich/Enrich.DAL/Entities/TrainingSession.cs
+++ b/Enrich/Enrich.DAL/Entities/TrainingSession.cs
@@ -6,7 +6,7 @@ namespace Enrich.DAL.Entities
 
         public required string UserId { get; set; }
 
-        public int BundleId { get; set; }
+        public int? BundleId { get; set; }
 
         public DateTime StartedAt { get; set; }
 
@@ -20,7 +20,7 @@ namespace Enrich.DAL.Entities
 
         public virtual User User { get; set; } = null!;
 
-        public virtual Bundle Bundle { get; set; } = null!;
+        public virtual Bundle? Bundle { get; set; }
 
         public virtual ICollection<SessionResult> SessionResults { get; set; } = new List<SessionResult>();
     }

--- a/Enrich/Enrich.DAL/Interfaces/IWordRepository.cs
+++ b/Enrich/Enrich.DAL/Interfaces/IWordRepository.cs
@@ -33,5 +33,7 @@ namespace Enrich.DAL.Interfaces
         Task<IEnumerable<Word>> GetAllWordsAsync();
 
         Task<IEnumerable<Word>> GetRandomWordsByCriteriaAsync(int? categoryId, string? partOfSpeech, string? minDifficulty, string? maxDifficulty, int count);
+
+        Task<IEnumerable<Word>> GetRandomPersonalWordsByCriteriaAsync(string userId, string? category, string? partOfSpeech, string? minDifficulty, string? maxDifficulty, int count);
     }
 }

--- a/Enrich/Enrich.DAL/Migrations/20260426204805_MakeBundleIdNullable.Designer.cs
+++ b/Enrich/Enrich.DAL/Migrations/20260426204805_MakeBundleIdNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Enrich.DAL.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Enrich.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426204805_MakeBundleIdNullable")]
+    partial class MakeBundleIdNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Enrich/Enrich.DAL/Migrations/20260426204805_MakeBundleIdNullable.cs
+++ b/Enrich/Enrich.DAL/Migrations/20260426204805_MakeBundleIdNullable.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Enrich.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeBundleIdNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TrainingSession_Bundle_BundleId",
+                table: "TrainingSession");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "BundleId",
+                table: "TrainingSession",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TrainingSession_Bundle_BundleId",
+                table: "TrainingSession",
+                column: "BundleId",
+                principalTable: "Bundle",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TrainingSession_Bundle_BundleId",
+                table: "TrainingSession");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "BundleId",
+                table: "TrainingSession",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TrainingSession_Bundle_BundleId",
+                table: "TrainingSession",
+                column: "BundleId",
+                principalTable: "Bundle",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Enrich/Enrich.DAL/Repositories/TrainingSessionRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/TrainingSessionRepository.cs
@@ -23,7 +23,7 @@ namespace Enrich.DAL.Repositories
         {
             return await dbContext.TrainingSessions
                 .Include(s => s.Bundle)
-                .ThenInclude(b => b.Words)
+                .ThenInclude(b => b!.Words)
                 .Include(s => s.SessionResults)
                 .ThenInclude(sr => sr.Word)
                 .FirstOrDefaultAsync(s => s.Id == sessionId);

--- a/Enrich/Enrich.DAL/Repositories/WordRepository.cs
+++ b/Enrich/Enrich.DAL/Repositories/WordRepository.cs
@@ -256,5 +256,47 @@ namespace Enrich.DAL.Repositories
                 .Take(count)
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<Word>> GetRandomPersonalWordsByCriteriaAsync(
+            string userId,
+            string? category,
+            string? partOfSpeech,
+            string? minDifficulty,
+            string? maxDifficulty,
+            int count)
+        {
+            var query = dbContext.UserWords
+                .Where(uw => uw.UserId == userId)
+                .Select(uw => uw.Word)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(category) && !category.Equals("Any", StringComparison.OrdinalIgnoreCase))
+            {
+                query = query.Where(w => w.Categories.Any(c => c.Name == category));
+            }
+
+            if (!string.IsNullOrWhiteSpace(partOfSpeech) && !partOfSpeech.Equals("Any", StringComparison.OrdinalIgnoreCase))
+            {
+                query = query.Where(w => w.PartOfSpeech == partOfSpeech);
+            }
+
+            if (!string.IsNullOrWhiteSpace(minDifficulty) || !string.IsNullOrWhiteSpace(maxDifficulty))
+            {
+                var levels = new List<string> { "A1", "A2", "B1", "B2", "C1", "C2" };
+                int minIdx = !string.IsNullOrWhiteSpace(minDifficulty) ? levels.IndexOf(minDifficulty) : 0;
+                int maxIdx = !string.IsNullOrWhiteSpace(maxDifficulty) ? levels.IndexOf(maxDifficulty) : levels.Count - 1;
+
+                if (minIdx != -1 && maxIdx != -1)
+                {
+                    var allowedLevels = levels.GetRange(minIdx, maxIdx - minIdx + 1);
+                    query = query.Where(w => w.DifficultyLevel != null && allowedLevels.Contains(w.DifficultyLevel));
+                }
+            }
+
+            return await query
+                .OrderBy(w => Guid.NewGuid())
+                .Take(count)
+                .ToListAsync();
+        }
     }
 }

--- a/Enrich/Enrich.UnitTests/Controllers/AdminBundleControllerTests.cs
+++ b/Enrich/Enrich.UnitTests/Controllers/AdminBundleControllerTests.cs
@@ -1,0 +1,106 @@
+﻿using Enrich.BLL.DTOs;
+using Enrich.BLL.Interfaces;
+using Enrich.DAL.Interfaces;
+using Enrich.Web.Controllers;
+using Enrich.Web.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+using NUnit.Framework;
+
+namespace Enrich.UnitTests.Controllers
+{
+    [TestFixture]
+    public class AdminBundleControllerTests
+    {
+        private Mock<IBundleService> _bundleServiceMock = null!;
+        private Mock<ICategoryRepository> _categoryRepositoryMock = null!;
+        private Mock<IWordRepository> _wordRepositoryMock = null!;
+        private AdminBundleController _controller = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _bundleServiceMock = new Mock<IBundleService>();
+            _categoryRepositoryMock = new Mock<ICategoryRepository>();
+            _wordRepositoryMock = new Mock<IWordRepository>();
+
+            _controller = new AdminBundleController(
+                _bundleServiceMock.Object,
+                _categoryRepositoryMock.Object,
+                _wordRepositoryMock.Object)
+            {
+                TempData = new TempDataDictionary(
+                    new DefaultHttpContext(),
+                    Mock.Of<ITempDataProvider>())
+            };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _controller?.Dispose();
+        }
+
+        [Test]
+        public async Task Index_ReturnsViewResult_WithPagedSystemBundles()
+        {
+            // Arrange
+            var pagedResult = new PagedResult<SystemBundleDTO>
+            {
+                Items = new List<SystemBundleDTO>
+                {
+                    new SystemBundleDTO { Id = 1, Title = "Sys Bundle" }
+                },
+                TotalCount = 1
+            };
+
+            _bundleServiceMock.Setup(s => s.GetSystemBundlesAsync(
+                It.IsAny<string>(),
+                null,
+                null,
+                null,
+                null,
+                1,
+                20))
+                .ReturnsAsync(pagedResult);
+
+            // Act
+            var result = await _controller.Index(1, string.Empty);
+
+            // Assert
+            Assert.That(result, Is.TypeOf<ViewResult>());
+            var viewResult = (ViewResult)result;
+
+            Assert.That(
+                viewResult.ViewData.Model,
+                Is.InstanceOf<PagedResult<SystemBundleDTO>>());
+
+            var model = (PagedResult<SystemBundleDTO>)viewResult.ViewData.Model!;
+            Assert.That(model.Items.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Create_Post_ValidModel_RedirectsToIndex()
+        {
+            // Arrange
+            var model = new CreateBundleViewModel
+            {
+                Title = "New Sys Bundle"
+            };
+
+            _bundleServiceMock.Setup(s => s.CreateSystemBundleAsync(It.IsAny<CreateBundleDTO>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _controller.Create(model);
+
+            // Assert
+            Assert.That(result, Is.TypeOf<RedirectToActionResult>());
+            var redirectResult = (RedirectToActionResult)result;
+
+            Assert.That(redirectResult.ActionName, Is.EqualTo("Index"));
+        }
+    }
+}

--- a/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
+++ b/Enrich/Enrich.UnitTests/Controllers/BundleControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json;
 using Enrich.BLL.Common;
 using Enrich.BLL.DTOs;
 using Enrich.BLL.Interfaces;
@@ -679,6 +680,60 @@ namespace Enrich.UnitTests.Controllers
 
             // Act
             var result = await _controller.SaveCommunityBundle(bundleId);
+
+            // Assert
+            var badRequestResult = result as BadRequestObjectResult;
+            Assert.That(badRequestResult, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task SaveGenerated_ValidRequest_ReturnsOk()
+        {
+            // Arrange
+            var model = new PreviewGeneratedViewModel
+            {
+                Title = "Generated Bundle",
+                Description = "Auto generated",
+                WordsJson = JsonSerializer.Serialize(new[] { new { Id = 1, Term = "Test", CategoryName = "General", DifficultyLevel = "A1" } })
+            };
+
+            _bundleServiceMock
+                .Setup(s => s.SaveGeneratedBundleAsync(TestUserId, It.IsAny<SaveGeneratedBundleDTO>()))
+                .ReturnsAsync(Result.Success());
+
+            // Act
+            var result = await _controller.SaveGenerated(model);
+
+            // Assert
+            var okResult = result as OkObjectResult;
+            Assert.That(okResult, Is.Not.Null);
+            _bundleServiceMock.Verify(
+                s => s.SaveGeneratedBundleAsync(
+                    TestUserId,
+                    It.Is<SaveGeneratedBundleDTO>(dto =>
+                        dto.Title == "Generated Bundle" &&
+                        dto.WordIds.Contains(1) &&
+                        dto.DifficultyLevels.Contains("A1") &&
+                        dto.CategoryNames.Contains("General"))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task SaveGenerated_WhenServiceReturnsError_ReturnsBadRequest()
+        {
+            // Arrange
+            var model = new PreviewGeneratedViewModel
+            {
+                Title = "Generated Bundle",
+                WordsJson = JsonSerializer.Serialize(new[] { new { Id = 1, Term = "Test" } })
+            };
+
+            _bundleServiceMock
+                .Setup(s => s.SaveGeneratedBundleAsync(TestUserId, It.IsAny<SaveGeneratedBundleDTO>()))
+                .ReturnsAsync(Result.Failure("Failed"));
+
+            // Act
+            var result = await _controller.SaveGenerated(model);
 
             // Assert
             var badRequestResult = result as BadRequestObjectResult;

--- a/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/BundleServiceTests.cs
@@ -500,5 +500,158 @@ namespace Enrich.UnitTests.Services
             Assert.That(result.ErrorMessage, Does.Contain("No words found"));
             _bundleRepositoryMock.Verify(r => r.CreateBundleAsync(It.IsAny<Bundle>()), Times.Never);
         }
+
+        [Test]
+        public async Task SaveGeneratedBundleAsync_DuplicateTitle_ReturnsError()
+        {
+            // Arrange
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = "Generated Bundle",
+                WordIds = new[] { 1 }
+            };
+
+            _bundleRepositoryMock
+                .Setup(r => r.BundleTitleExistsForUserAsync(TestUserId, "generated bundle"))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _bundleService.SaveGeneratedBundleAsync(TestUserId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("already have a bundle"));
+            _bundleRepositoryMock.Verify(r => r.CreateBundleAsync(It.IsAny<Bundle>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SaveGeneratedBundleAsync_ValidData_SavesBundleWithWordsAndCategories()
+        {
+            // Arrange
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = "Generated Bundle",
+                Description = "Auto generated bundle",
+                WordIds = new[] { 2, 5 },
+                DifficultyLevels = ["A1", "B1"],
+                CategoryNames = ["General", "Science"]
+            };
+
+            var createdBundle = new Bundle { Id = 101 };
+
+            _bundleRepositoryMock
+                .Setup(r => r.BundleTitleExistsForUserAsync(TestUserId, "generated bundle"))
+                .ReturnsAsync(false);
+
+            _bundleRepositoryMock
+                .Setup(r => r.CreateBundleAsync(It.IsAny<Bundle>()))
+                .ReturnsAsync(createdBundle);
+
+            _categoryRepositoryMock
+                .Setup(r => r.GetCategoryByNameAsync("General"))
+                .ReturnsAsync(new Category { Id = 7, Name = "General" });
+            _categoryRepositoryMock
+                .Setup(r => r.GetCategoryByNameAsync("Science"))
+                .ReturnsAsync(new Category { Id = 8, Name = "Science" });
+
+            // Act
+            var result = await _bundleService.SaveGeneratedBundleAsync(TestUserId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            _bundleRepositoryMock.Verify(
+                r => r.AddWordsToBundleAsync(
+                    createdBundle.Id,
+                    It.Is<IEnumerable<int>>(ids => ids.Contains(2) && ids.Contains(5))),
+                Times.Once);
+            _bundleRepositoryMock.Verify(
+                r => r.AddCategoriesToBundleAsync(
+                    createdBundle.Id,
+                    It.Is<IEnumerable<int>>(ids => ids.Contains(7) && ids.Contains(8))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task CreateSystemBundleAsync_ValidDto_SetsSystemFlagsAndStatus()
+        {
+            // Arrange
+            var dto = new CreateBundleDTO
+            {
+                Title = "New System Collection",
+                CategoryIds = new List<int> { 1 },
+                WordIds = new List<int> { 10, 11 }
+            };
+
+            _bundleRepositoryMock
+                .Setup(r => r.CreateBundleAsync(It.IsAny<Bundle>()))
+                .ReturnsAsync((Bundle b) =>
+                {
+                    b.Id = 100;
+                    return b;
+                });
+
+            // Act
+            var result = await _bundleService.CreateSystemBundleAsync(dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            _bundleRepositoryMock.Verify(
+                r => r.CreateBundleAsync(It.Is<Bundle>(b =>
+                b.Title == "New System Collection" &&
+                b.IsSystem &&
+                b.OwnerId == "SYSTEM" &&
+                b.Status == BundleStatus.Published)),
+                Times.Once);
+
+            _bundleRepositoryMock.Verify(r => r.AddWordsToBundleAsync(100, dto.WordIds), Times.Once);
+            _bundleRepositoryMock.Verify(r => r.AddCategoriesToBundleAsync(100, dto.CategoryIds), Times.Once);
+        }
+
+        [Test]
+        public async Task UpdateSystemBundleAsync_ExistingSystemBundle_UpdatesAndSyncs()
+        {
+            // Arrange
+            var bundleId = 55;
+            var systemBundle = new Bundle { Id = bundleId, IsSystem = true, Title = "Old Title" };
+            var dto = new CreateBundleDTO
+            {
+                Title = "Updated Title",
+                WordIds = new List<int> { 1, 2 },
+                CategoryIds = new List<int> { 3 }
+            };
+
+            _bundleRepositoryMock.Setup(r => r.GetBundleByIdAsync(bundleId))
+                .ReturnsAsync(systemBundle);
+
+            // Act
+            var result = await _bundleService.UpdateSystemBundleAsync(bundleId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(systemBundle.Title, Is.EqualTo("Updated Title"));
+
+            _bundleRepositoryMock.Verify(r => r.UpdateBundleAsync(systemBundle), Times.Once);
+            _bundleRepositoryMock.Verify(r => r.SyncBundleRelationsAsync(bundleId, dto.WordIds, dto.CategoryIds), Times.Once);
+        }
+
+        [Test]
+        public async Task UpdateSystemBundleAsync_NonSystemBundle_ReturnsError()
+        {
+            // Arrange
+            var bundleId = 1;
+            var userBundle = new Bundle { Id = bundleId, IsSystem = false };
+            var dto = new CreateBundleDTO { Title = "Hacker Title" };
+
+            _bundleRepositoryMock.Setup(r => r.GetBundleByIdAsync(bundleId))
+                .ReturnsAsync(userBundle);
+
+            // Act
+            var result = await _bundleService.UpdateSystemBundleAsync(bundleId, dto);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("System bundle not found."));
+            _bundleRepositoryMock.Verify(r => r.UpdateBundleAsync(It.IsAny<Bundle>()), Times.Never);
+        }
     }
 }

--- a/Enrich/Enrich.UnitTests/Services/QuizServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/QuizServiceTests.cs
@@ -1,0 +1,113 @@
+using Enrich.BLL.DTOs;
+using Enrich.BLL.Services;
+using Enrich.DAL.Entities;
+using Enrich.DAL.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace Enrich.UnitTests.Services
+{
+    [TestFixture]
+    public class QuizServiceTests
+    {
+        private Mock<IWordRepository> _wordRepositoryMock = null!;
+        private Mock<ITrainingSessionRepository> _trainingSessionRepositoryMock = null!;
+        private Mock<ILogger<QuizService>> _loggerMock = null!;
+        private QuizService _quizService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _wordRepositoryMock = new Mock<IWordRepository>();
+            _trainingSessionRepositoryMock = new Mock<ITrainingSessionRepository>();
+            _loggerMock = new Mock<ILogger<QuizService>>();
+
+            _quizService = new QuizService(
+                _wordRepositoryMock.Object,
+                _trainingSessionRepositoryMock.Object,
+                _loggerMock.Object);
+        }
+
+        [Test]
+        public async Task StartCustomQuizAsync_WhenWordsFound_CreatesSessionAndReturnsDto()
+        {
+            // Arrange
+            var userId = "user-1";
+            var setup = new QuizSetupDTO { WordCount = 5 };
+            var words = new List<Word>
+            {
+                new Word { Id = 1, Term = "Word1", Translation = "Trans1" },
+                new Word { Id = 2, Term = "Word2", Translation = "Trans2" }
+            };
+
+            _wordRepositoryMock
+                .Setup(r => r.GetRandomPersonalWordsByCriteriaAsync(userId, null, null, null, null, 5))
+                .ReturnsAsync(words);
+
+            _trainingSessionRepositoryMock
+                .Setup(r => r.CreateSessionAsync(It.IsAny<TrainingSession>()))
+                .ReturnsAsync((TrainingSession s) =>
+                {
+                    s.Id = 100;
+                    return s;
+                });
+
+            // Act
+            var result = await _quizService.StartCustomQuizAsync(userId, setup);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Value!.SessionId, Is.EqualTo(100));
+            Assert.That(result.Value.Cards.Count, Is.EqualTo(2));
+            Assert.That(result.Value.Cards[0].Term, Is.EqualTo("Word1"));
+            _trainingSessionRepositoryMock.Verify(r => r.CreateSessionAsync(It.Is<TrainingSession>(s => s.UserId == userId && s.BundleId == null)), Times.Once);
+        }
+
+        [Test]
+        public async Task StartCustomQuizAsync_WhenNoWordsFound_ReturnsFailure()
+        {
+            // Arrange
+            var userId = "user-1";
+            var setup = new QuizSetupDTO { WordCount = 5 };
+
+            _wordRepositoryMock
+                .Setup(r => r.GetRandomPersonalWordsByCriteriaAsync(userId, null, null, null, null, 5))
+                .ReturnsAsync(new List<Word>());
+
+            // Act
+            var result = await _quizService.StartCustomQuizAsync(userId, setup);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("No words found matching the specified criteria."));
+            _trainingSessionRepositoryMock.Verify(r => r.CreateSessionAsync(It.IsAny<TrainingSession>()), Times.Never);
+        }
+
+        [Test]
+        public async Task GetAvailableCategoriesAsync_ReturnsDistinctCategories()
+        {
+            // Arrange
+            var userId = "user-1";
+            var cat1 = new Category { Name = "Tech" };
+            var cat2 = new Category { Name = "Science" };
+            var userWords = new List<UserWord>
+            {
+                new UserWord { UserId = userId, Word = new Word { Categories = new List<Category> { cat1 } } },
+                new UserWord { UserId = userId, Word = new Word { Categories = new List<Category> { cat1, cat2 } } }
+            };
+
+            _wordRepositoryMock.Setup(r => r.GetPersonalWordsWithDetailsAsync(userId)).ReturnsAsync(userWords);
+
+            // Act
+            var result = await _quizService.GetAvailableCategoriesAsync(userId);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            var list = result.Value!.ToList();
+            Assert.That(list.Count, Is.EqualTo(2));
+            Assert.That(list, Contains.Item("Tech"));
+            Assert.That(list, Contains.Item("Science"));
+        }
+    }
+}

--- a/Enrich/Enrich.UnitTests/Services/WordServiceTests.cs
+++ b/Enrich/Enrich.UnitTests/Services/WordServiceTests.cs
@@ -308,6 +308,45 @@ namespace Enrich.UnitTests.Services
         }
 
         [Test]
+        public async Task SaveWordToLibraryAsync_WhenWordExistsAndNotSaved_ReturnsSuccess()
+        {
+            // Arrange
+            var userId = "user-1";
+            var word = new Word { Id = 4, Term = "Practice" };
+
+            _wordRepositoryMock.Setup(r => r.GetWordAsync(word.Id)).ReturnsAsync(word);
+            _wordRepositoryMock.Setup(r => r.UserHasWordAsync(userId, word.Id)).ReturnsAsync(false);
+
+            // Act
+            var result = await _wordService.SaveWordToLibraryAsync(userId, word.Id);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.True);
+            _wordRepositoryMock.Verify(
+                r => r.SaveUserWordAsync(It.Is<UserWord>(uw => uw.UserId == userId && uw.WordId == word.Id)),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task SaveWordToLibraryAsync_WhenWordAlreadySaved_ReturnsFailure()
+        {
+            // Arrange
+            var userId = "user-1";
+            var word = new Word { Id = 7, Term = "Repeat" };
+
+            _wordRepositoryMock.Setup(r => r.GetWordAsync(word.Id)).ReturnsAsync(word);
+            _wordRepositoryMock.Setup(r => r.UserHasWordAsync(userId, word.Id)).ReturnsAsync(true);
+
+            // Act
+            var result = await _wordService.SaveWordToLibraryAsync(userId, word.Id);
+
+            // Assert
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("You have already saved this word."));
+            _wordRepositoryMock.Verify(r => r.SaveUserWordAsync(It.IsAny<UserWord>()), Times.Never);
+        }
+
+        [Test]
         public async Task GetPersonalWordForEditAsync_UserIsOwner_ReturnsWord()
         {
             // Arrange

--- a/Enrich/Enrich.Web/Controllers/AdminBundleController.cs
+++ b/Enrich/Enrich.Web/Controllers/AdminBundleController.cs
@@ -1,0 +1,160 @@
+using Enrich.BLL.DTOs;
+using Enrich.BLL.Interfaces;
+using Enrich.DAL.Entities.Enums;
+using Enrich.DAL.Interfaces;
+using Enrich.Web.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Enrich.Web.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    [Route("Admin/Bundles")]
+    public class AdminBundleController(
+        IBundleService bundleService,
+        ICategoryRepository categoryRepository,
+        IWordRepository wordRepository) : Controller
+    {
+        [HttpGet]
+        public async Task<IActionResult> Index(int page = 1, string search = "")
+        {
+            var pagedResult = await bundleService.GetSystemBundlesAsync(search, null, null, null, null, page, 20);
+            ViewBag.SearchTerm = search;
+            return View(pagedResult);
+        }
+
+        [HttpGet("Create")]
+        public async Task<IActionResult> Create()
+        {
+            var viewModel = new CreateBundleViewModel();
+            await PopulateDropdowns(viewModel);
+            return View(viewModel);
+        }
+
+        [HttpPost("Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(CreateBundleViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                await PopulateDropdowns(model);
+                return View(model);
+            }
+
+            var dto = new CreateBundleDTO
+            {
+                Title = model.Title,
+                Description = model.Description,
+                DifficultyLevels = model.DifficultyLevels?.ToArray() ?? [],
+                ImageUrl = model.ImageUrl,
+                CategoryIds = model.CategoryIds,
+                WordIds = model.WordIds
+            };
+
+            var result = await bundleService.CreateSystemBundleAsync(dto);
+            if (!result.IsSuccess)
+            {
+                ModelState.AddModelError(string.Empty, result.ErrorMessage ?? "Помилка створення.");
+                await PopulateDropdowns(model);
+                return View(model);
+            }
+
+            TempData["SuccessMessage"] = "Системний бандл успішно створено!";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet("Edit/{id}")]
+        public async Task<IActionResult> Edit(int id)
+        {
+            var bundle = await bundleService.GetBundleByIdAsync(id);
+            if (bundle == null || !bundle.IsSystem)
+            {
+                return NotFound();
+            }
+
+            var viewModel = new EditBundleViewModel
+            {
+                Id = bundle.Id,
+                Title = bundle.Title,
+                Description = bundle.Description,
+                ImageUrl = bundle.ImageUrl,
+                Status = Enum.Parse<BundleStatus>(bundle.Status, true),
+                CategoryIds = bundle.CategoryIds,
+                WordIds = bundle.WordIds,
+                DifficultyLevels = bundle.DifficultyLevels?.ToList() ?? []
+            };
+
+            await PopulateDropdowns(viewModel);
+            return View(viewModel);
+        }
+
+        [HttpPost("Edit/{id}")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, EditBundleViewModel model)
+        {
+            if (id != model.Id)
+            {
+                return BadRequest();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                await PopulateDropdowns(model);
+                return View(model);
+            }
+
+            var dto = new CreateBundleDTO
+            {
+                Title = model.Title,
+                Description = model.Description,
+                DifficultyLevels = model.DifficultyLevels?.ToArray() ?? [],
+                ImageUrl = model.ImageUrl,
+                CategoryIds = model.CategoryIds,
+                WordIds = model.WordIds
+            };
+
+            var result = await bundleService.UpdateSystemBundleAsync(id, dto);
+            if (!result.IsSuccess)
+            {
+                ModelState.AddModelError(string.Empty, result.ErrorMessage ?? "Помилка оновлення.");
+                await PopulateDropdowns(model);
+                return View(model);
+            }
+
+            TempData["SuccessMessage"] = "Системний бандл успішно оновлено!";
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost("Delete/{id}")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var bundle = await bundleService.GetBundleByIdAsync(id);
+            if (bundle != null && bundle.IsSystem)
+            {
+                await bundleService.DeleteBundleAsync(bundle.OwnerId ?? "SYSTEM", id);
+                TempData["SuccessMessage"] = "Бандл видалено.";
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        private async Task PopulateDropdowns(CreateBundleViewModel model)
+        {
+            var categories = await categoryRepository.GetAllCategoriesAsync();
+            var words = await wordRepository.GetAllWordsAsync();
+            model.Categories = categories.Select(c => (c.Id, c.Name)).ToList();
+            model.Words = words.Select(w => new WordItemViewModel { Id = w.Id, Term = w.Term, Translation = w.Translation }).ToList();
+            model.AvailableLevels = ["A1", "A2", "B1", "B2", "C1", "C2"];
+        }
+
+        private async Task PopulateDropdowns(EditBundleViewModel model)
+        {
+            var categories = await categoryRepository.GetAllCategoriesAsync();
+            var words = await wordRepository.GetAllWordsAsync();
+            model.Categories = categories.Select(c => (c.Id, c.Name)).ToList();
+            model.Words = words.Select(w => new WordItemViewModel { Id = w.Id, Term = w.Term, Translation = w.Translation }).ToList();
+            model.AvailableLevels = ["A1", "A2", "B1", "B2", "C1", "C2"];
+        }
+    }
+}

--- a/Enrich/Enrich.Web/Controllers/BundleController.cs
+++ b/Enrich/Enrich.Web/Controllers/BundleController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Enrich.BLL.DTOs;
 using Enrich.BLL.Interfaces;
 using Enrich.BLL.Settings;
@@ -278,6 +279,62 @@ namespace Enrich.Web.Controllers
             }
 
             return Ok();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> SaveGenerated([FromBody] PreviewGeneratedViewModel model)
+        {
+            if (model == null)
+            {
+                logger.LogWarning("User {UserId} submitted an empty generated bundle save request.", CurrentUserId);
+                return BadRequest(new { message = "Invalid data." });
+            }
+
+            List<SystemWordDTO> words;
+            try
+            {
+                words = model.Words;
+            }
+            catch (JsonException ex)
+            {
+                logger.LogWarning(ex, "User {UserId} submitted invalid generated bundle words payload.", CurrentUserId);
+                return BadRequest(new { message = "Invalid words data." });
+            }
+
+            var wordIds = words.Select(w => w.Id).Where(id => id > 0).Distinct().ToList();
+            if (!wordIds.Any())
+            {
+                logger.LogWarning("User {UserId} attempted to save a generated bundle without words.", CurrentUserId);
+                return BadRequest(new { message = "Generated bundle has no words to save." });
+            }
+
+            var dto = new SaveGeneratedBundleDTO
+            {
+                Title = model.Title?.Trim() ?? string.Empty,
+                Description = model.Description?.Trim(),
+                WordIds = wordIds,
+                DifficultyLevels = words
+                    .Where(w => !string.IsNullOrWhiteSpace(w.DifficultyLevel))
+                    .Select(w => w.DifficultyLevel!.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                CategoryNames = words
+                    .Select(w => w.CategoryName?.Trim())
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Select(name => name!)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray()
+            };
+
+            var result = await bundleService.SaveGeneratedBundleAsync(CurrentUserId, dto);
+            if (!result.IsSuccess)
+            {
+                return BadRequest(new { message = result.ErrorMessage });
+            }
+
+            logger.LogInformation("User {UserId} saved generated bundle '{Title}'.", CurrentUserId, dto.Title);
+            return Ok(new { message = "Collection saved.", redirectUrl = Url?.Action("Index", "Bundle") });
         }
 
         [HttpPost]

--- a/Enrich/Enrich.Web/Controllers/QuizController.cs
+++ b/Enrich/Enrich.Web/Controllers/QuizController.cs
@@ -1,0 +1,83 @@
+using Enrich.BLL.DTOs;
+using Enrich.BLL.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Enrich.Web.Controllers
+{
+    [Authorize]
+    public class QuizController(
+        IQuizService quizService,
+        IStudySessionService studySessionService,
+        ILogger<QuizController> logger) : BaseController
+    {
+        [HttpGet]
+        public async Task<IActionResult> Setup()
+        {
+            logger.LogInformation("User {UserId} accessed quiz setup.", CurrentUserId);
+            var categoriesResult = await quizService.GetAvailableCategoriesAsync(CurrentUserId);
+            var partsOfSpeechResult = await quizService.GetAvailablePartsOfSpeechAsync(CurrentUserId);
+
+            ViewBag.Categories = categoriesResult.IsSuccess ? categoriesResult.Value : new List<string>();
+            ViewBag.PartsOfSpeech = partsOfSpeechResult.IsSuccess ? partsOfSpeechResult.Value : new List<string>();
+
+            return View(new QuizSetupDTO());
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Start(QuizSetupDTO setup)
+        {
+            logger.LogInformation("User {UserId} is starting a custom quiz session.", CurrentUserId);
+            var result = await quizService.StartCustomQuizAsync(CurrentUserId, setup);
+
+            if (!result.IsSuccess)
+            {
+                TempData["Error"] = result.ErrorMessage;
+                return RedirectToAction(nameof(Setup));
+            }
+
+            return View("Session", result.Value);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> SubmitAnswer([FromBody] SubmitAnswerDTO dto)
+        {
+            var result = await studySessionService.SubmitAnswerAsync(CurrentUserId, dto);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Json(result.Value);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Finish(int sessionId)
+        {
+            logger.LogInformation("User {UserId} is finishing session {SessionId}.", CurrentUserId, sessionId);
+            var result = await studySessionService.FinishStudySessionAsync(CurrentUserId, sessionId);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return RedirectToAction(nameof(Result), new { sessionId });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Result(int sessionId)
+        {
+            logger.LogInformation("User {UserId} is viewing results for session {SessionId}.", CurrentUserId, sessionId);
+            var progressResult = await studySessionService.GetSessionProgressAsync(CurrentUserId, sessionId);
+
+            if (!progressResult.IsSuccess)
+            {
+                return RedirectToAction("Index", "Home");
+            }
+
+            return View(progressResult.Value);
+        }
+    }
+}

--- a/Enrich/Enrich.Web/Controllers/WordController.cs
+++ b/Enrich/Enrich.Web/Controllers/WordController.cs
@@ -220,6 +220,30 @@ namespace Enrich.Web.Controllers
             return categoryIds;
         }
 
+        [HttpPost("Words/AddToMyWords")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> AddToMyWords([FromBody] SaveWordRequest request)
+        {
+            if (request == null || request.WordId <= 0)
+            {
+                logger.LogWarning("User {UserId} submitted an invalid save word request.", CurrentUserId);
+                return BadRequest(new { message = "Invalid word data." });
+            }
+
+            var result = await wordService.SaveWordToLibraryAsync(CurrentUserId, request.WordId);
+            if (!result.IsSuccess)
+            {
+                logger.LogWarning(
+                    "User {UserId} failed to save word {WordId} from study: {Error}.",
+                    CurrentUserId,
+                    request.WordId,
+                    result.ErrorMessage);
+                return BadRequest(new { message = result.ErrorMessage });
+            }
+
+            return Ok(new { message = "Word saved to your library." });
+        }
+
         [HttpPost]
         public async Task<IActionResult> SaveSystemWord(int id)
         {

--- a/Enrich/Enrich.Web/Enrich.Web.csproj
+++ b/Enrich/Enrich.Web/Enrich.Web.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	<UserSecretsId>0b3db9af-3af8-4478-8efd-c84696a8c34d</UserSecretsId>
+    <StaticWebAssetCompressionEnabled>false</StaticWebAssetCompressionEnabled>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Enrich.BLL\Enrich.BLL.csproj" />
     <ProjectReference Include="..\Enrich.DAL\Enrich.DAL.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Views\AdminBundle\" />
   </ItemGroup>
 
 </Project>

--- a/Enrich/Enrich.Web/Views/AdminBundle/Create.cshtml
+++ b/Enrich/Enrich.Web/Views/AdminBundle/Create.cshtml
@@ -1,0 +1,71 @@
+@model Enrich.Web.ViewModels.CreateBundleViewModel
+@{
+    ViewData["Title"] = "Create System Bundle";
+}
+
+<div class="container mt-4">
+    <h2>Create System Bundle</h2>
+    <hr />
+    <form asp-action="Create" method="post">
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label asp-for="Title" class="form-label fw-bold"></label>
+                    <input asp-for="Title" class="form-control" />
+                    <span asp-validation-for="Title" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Description" class="form-label fw-bold"></label>
+                    <textarea asp-for="Description" class="form-control" rows="3"></textarea>
+                    <span asp-validation-for="Description" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="ImageUrl" class="form-label fw-bold"></label>
+                    <input asp-for="ImageUrl" class="form-control" placeholder="https://..." />
+                    <span asp-validation-for="ImageUrl" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label asp-for="CategoryIds" class="form-label fw-bold"></label>
+                    <select asp-for="CategoryIds" class="form-select" multiple size="4">
+                        @foreach (var cat in Model.Categories)
+                        {
+                            <option value="@cat.Id">@cat.Name</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="DifficultyLevels" class="form-label fw-bold"></label>
+                    <select asp-for="DifficultyLevels" class="form-select" multiple size="4">
+                        @foreach (var level in Model.AvailableLevels)
+                        {
+                            <option value="@level">@level</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="WordIds" class="form-label fw-bold"></label>
+                    <select asp-for="WordIds" class="form-select" multiple size="5">
+                        @foreach (var word in Model.Words)
+                        {
+                            <option value="@word.Id">@word.Term - @word.Translation</option>
+                        }
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-4">
+            <button type="submit" class="btn btn-success px-4">Create</button>
+            <a asp-action="Index" class="btn btn-secondary ms-2">Back to List</a>
+        </div>
+    </form>
+</div>

--- a/Enrich/Enrich.Web/Views/AdminBundle/Edit.cshtml
+++ b/Enrich/Enrich.Web/Views/AdminBundle/Edit.cshtml
@@ -1,0 +1,72 @@
+@model Enrich.Web.ViewModels.EditBundleViewModel
+@{
+    ViewData["Title"] = "Edit System Bundle";
+}
+
+<div class="container mt-4">
+    <h2>Edit System Bundle: @Model.Title</h2>
+    <hr />
+    <form asp-action="Edit" method="post">
+        <input type="hidden" asp-for="Id" />
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label asp-for="Title" class="form-label fw-bold"></label>
+                    <input asp-for="Title" class="form-control" />
+                    <span asp-validation-for="Title" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Description" class="form-label fw-bold"></label>
+                    <textarea asp-for="Description" class="form-control" rows="3"></textarea>
+                    <span asp-validation-for="Description" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="ImageUrl" class="form-label fw-bold"></label>
+                    <input asp-for="ImageUrl" class="form-control" />
+                    <span asp-validation-for="ImageUrl" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label asp-for="CategoryIds" class="form-label fw-bold"></label>
+                    <select asp-for="CategoryIds" class="form-select" multiple size="4">
+                        @foreach (var cat in Model.Categories)
+                        {
+                            <option value="@cat.Id">@cat.Name</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="DifficultyLevels" class="form-label fw-bold"></label>
+                    <select asp-for="DifficultyLevels" class="form-select" multiple size="4">
+                        @foreach (var level in Model.AvailableLevels)
+                        {
+                            <option value="@level">@level</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="WordIds" class="form-label fw-bold"></label>
+                    <select asp-for="WordIds" class="form-select" multiple size="5">
+                        @foreach (var word in Model.Words)
+                        {
+                            <option value="@word.Id">@word.Term - @word.Translation</option>
+                        }
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-4">
+            <button type="submit" class="btn btn-primary px-4">Save Changes</button>
+            <a asp-action="Index" class="btn btn-secondary ms-2">Back to List</a>
+        </div>
+    </form>
+</div>

--- a/Enrich/Enrich.Web/Views/AdminBundle/Index.cshtml
+++ b/Enrich/Enrich.Web/Views/AdminBundle/Index.cshtml
@@ -1,0 +1,52 @@
+@model Enrich.BLL.DTOs.PagedResult<Enrich.BLL.DTOs.SystemBundleDTO>
+@{
+    ViewData["Title"] = "Manage System Bundles";
+}
+
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>System Bundles Management</h2>
+        <a asp-action="Create" class="btn btn-success">Create New System Bundle</a>
+    </div>
+
+    @if (TempData["SuccessMessage"] != null)
+    {
+        <div class="alert alert-success">@TempData["SuccessMessage"]</div>
+    }
+
+    <form method="get" class="mb-4 d-flex">
+        <input type="text" name="search" value="@ViewBag.SearchTerm" class="form-control me-2" placeholder="Search collections..." />
+        <button type="submit" class="btn btn-primary">Search</button>
+    </form>
+
+    <table class="table table-striped table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>Title</th>
+                <th>Words Count</th>
+                <th>Categories</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (!Model.Items.Any())
+            {
+                <tr><td colspan="4" class="text-center">No system bundles found.</td></tr>
+            }
+            @foreach (var item in Model.Items)
+            {
+                <tr>
+                    <td class="align-middle"><strong>@item.Title</strong></td>
+                    <td class="align-middle">@item.WordCount</td>
+                    <td class="align-middle">@(string.Join(", ", item.Categories))</td>
+                    <td class="align-middle">
+                        <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary me-2">Edit</a>
+                        <form asp-action="Delete" asp-route-id="@item.Id" method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this system collection?');">
+                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/Enrich/Enrich.Web/Views/Bundle/PreviewGenerated.cshtml
+++ b/Enrich/Enrich.Web/Views/Bundle/PreviewGenerated.cshtml
@@ -180,8 +180,13 @@
                     </div>
                 </div>
 
+                <input type="hidden" id="generatedTitle" value="@Model.Title" />
+                <input type="hidden" id="generatedDescription" value="@Model.Description" />
+                <input type="hidden" id="generatedWordsJson" value="@Model.WordsJson" />
+                @Html.AntiForgeryToken()
+
                 <div class="d-flex gap-2 mt-auto flex-column flex-sm-row">
-                    <button class="btn btn-action-success rounded-4 w-100 justify-content-center">
+                    <button id="btnSaveGenerated" type="button" class="btn btn-action-success rounded-4 w-100 justify-content-center">
                         <i class="bi bi-plus-circle me-2"></i> Add to My Collections
                     </button>
                     <button class="btn btn-action-outline-success rounded-4 w-100 justify-content-center">
@@ -262,3 +267,61 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script>
+        document.getElementById('btnSaveGenerated').addEventListener('click', async () => {
+            const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+            if (!token) {
+                showToast('Verification token missing.', 'danger');
+                return;
+            }
+
+            const payload = {
+                title: document.getElementById('generatedTitle').value,
+                description: document.getElementById('generatedDescription').value,
+                wordsJson: document.getElementById('generatedWordsJson').value
+            };
+
+            const btn = document.getElementById('btnSaveGenerated');
+            const originalText = btn.innerText;
+            btn.disabled = true;
+            btn.innerText = 'Saving...';
+
+            try {
+                const response = await fetch('@Url.Action("SaveGenerated", "Bundle")', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': token
+                    },
+                    body: JSON.stringify(payload)
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    showToast(data.message || 'Collection saved.', 'success');
+                    if (data.redirectUrl) {
+                        window.location.href = data.redirectUrl;
+                        return;
+                    }
+                } else {
+                    let errorMessage = 'Failed to save the collection.';
+                    try {
+                        const error = await response.json();
+                        errorMessage = error.message || errorMessage;
+                    } catch (err) {
+                        console.error(err);
+                    }
+                    showToast(errorMessage, 'danger');
+                }
+            } catch (err) {
+                console.error(err);
+                showToast('An unexpected error occurred.', 'danger');
+            } finally {
+                btn.disabled = false;
+                btn.innerText = originalText;
+            }
+        });
+    </script>
+}

--- a/Enrich/Enrich.Web/Views/Quiz/Result.cshtml
+++ b/Enrich/Enrich.Web/Views/Quiz/Result.cshtml
@@ -1,0 +1,135 @@
+@model Enrich.BLL.DTOs.StudyProgressDTO
+@{
+    ViewData["Title"] = "Quiz Result";
+    Layout = "~/Views/Shared/_AppLayout.cshtml";
+}
+
+<style>
+    .result-page {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 80vh;
+        font-family: 'Open Sans', sans-serif;
+        text-align: center;
+    }
+
+    .star-icon {
+        color: #ffc107;
+        font-size: 5rem;
+        margin-bottom: 10px;
+    }
+
+    .session-title {
+        font-size: 3.5rem;
+        font-weight: 800;
+        margin-bottom: 40px;
+        color: #212529;
+    }
+
+    .points-circle {
+        width: 180px;
+        height: 180px;
+        border-radius: 50%;
+        border: 2px solid #D1E7DD;
+        background-color: #F8FCF9;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 50px;
+    }
+
+    .points-value {
+        font-size: 4rem;
+        font-weight: 800;
+        color: #198754;
+        line-height: 1;
+    }
+
+    .points-label {
+        font-size: 1rem;
+        font-weight: 700;
+        color: #198754;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .mastery-text {
+        font-size: 1.5rem;
+        color: #6C757D;
+        margin-bottom: 50px;
+    }
+
+    .mastery-text strong {
+        color: #212529;
+    }
+
+    .result-buttons {
+        display: flex;
+        gap: 20px;
+        width: 100%;
+        max-width: 550px;
+    }
+
+    .btn-result {
+        flex: 1;
+        padding: 16px;
+        border-radius: 12px;
+        font-weight: 700;
+        font-size: 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        transition: all 0.2s;
+        text-decoration: none;
+    }
+
+    .btn-white {
+        background: white;
+        border: 1px solid #E9ECEF;
+        color: #212529;
+    }
+
+    .btn-white:hover {
+        background: #F8F9FA;
+    }
+
+    .btn-green {
+        background: #198754;
+        color: white;
+        border: none;
+    }
+
+    .btn-green:hover {
+        background: #157347;
+    }
+</style>
+
+<div class="result-page">
+    <div class="star-icon">
+        <i class="bi bi-star-fill"></i>
+    </div>
+    
+    <h1 class="session-title">Session Finished!</h1>
+
+    <div class="points-circle">
+        <div class="points-value">@Model.TotalPoints</div>
+        <div class="points-label">Points</div>
+    </div>
+
+    <p class="mastery-text">
+        You've mastered <strong>@Model.KnownCount</strong> out of @Model.TotalCards words!
+    </p>
+
+    <div class="result-buttons">
+        <a asp-action="Setup" class="btn-result btn-white">
+            <i class="bi bi-arrow-clockwise"></i> Restart
+        </a>
+        <a asp-controller="Word" asp-action="MyWords" class="btn-result btn-green">
+            Return to My Words
+        </a>
+    </div>
+</div>

--- a/Enrich/Enrich.Web/Views/Quiz/Session.cshtml
+++ b/Enrich/Enrich.Web/Views/Quiz/Session.cshtml
@@ -1,0 +1,233 @@
+@model Enrich.BLL.DTOs.StudySessionDTO
+@{
+    ViewData["Title"] = "Quiz Session";
+    Layout = "~/Views/Shared/_AppLayout.cshtml";
+}
+
+<style>
+    .quiz-page {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 80vh;
+        font-family: 'Open Sans', sans-serif;
+    }
+
+    .progress-counter {
+        font-size: 2rem;
+        font-weight: 800;
+        margin-bottom: 30px;
+        color: #212529;
+    }
+
+    .quiz-card {
+        background: white;
+        border-radius: 24px;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+        width: 100%;
+        max-width: 650px;
+        height: 350px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+        cursor: pointer;
+        transition: transform 0.2s;
+        margin-bottom: 40px;
+        perspective: 1000px;
+    }
+
+    .quiz-card:hover {
+        transform: translateY(-2px);
+    }
+
+    .card-inner {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        text-align: center;
+        transition: transform 0.6s;
+        transform-style: preserve-3d;
+    }
+
+    .quiz-card.flipped .card-inner {
+        transform: rotateY(180deg);
+    }
+
+    .card-front, .card-back {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        backface-visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        padding: 40px;
+    }
+
+    .card-back {
+        transform: rotateY(180deg);
+    }
+
+    .word-term {
+        font-size: 3.5rem;
+        font-weight: 800;
+        color: #212529;
+        margin-bottom: 8px;
+    }
+
+    .word-transcription {
+        font-size: 1.25rem;
+        color: #adb5bd;
+        margin-bottom: 20px;
+    }
+
+    .word-translation {
+        font-size: 3rem;
+        font-weight: 800;
+        color: #198754;
+    }
+
+    .tap-to-flip {
+        position: absolute;
+        bottom: 30px;
+        color: #adb5bd;
+        font-size: 0.9rem;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .quiz-buttons {
+        display: flex;
+        gap: 15px;
+        width: 100%;
+        max-width: 650px;
+    }
+
+    .btn-quiz {
+        flex: 1;
+        padding: 14px;
+        border-radius: 12px;
+        font-weight: 600;
+        font-size: 0.95rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        transition: all 0.2s;
+    }
+
+    .btn-outline-custom {
+        background: #f8f9fa;
+        border: 1px solid #e9ecef;
+        color: #212529;
+    }
+
+    .btn-outline-custom:hover {
+        background: #e9ecef;
+    }
+
+    .btn-success-custom {
+        background: #198754;
+        color: white;
+        border: none;
+    }
+
+    .btn-success-custom:hover {
+        background: #157347;
+    }
+</style>
+
+<div class="quiz-page">
+    <div id="progressCounter" class="progress-counter">1/@Model.TotalCards</div>
+
+    <div class="quiz-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-inner">
+            <div class="card-front">
+                <div id="frontTerm" class="word-term">Algorithm</div>
+                <div id="frontTranscription" class="word-transcription">[ˈælɡərɪðəm]</div>
+                <div class="tap-to-flip">
+                    <i class="bi bi-arrow-repeat"></i> Tap to flip
+                </div>
+            </div>
+            <div class="card-back">
+                <div id="backTranslation" class="word-translation">Алгоритм</div>
+                <div id="backMeaning" class="text-muted mt-2">A set of rules for solving a problem.</div>
+                <div class="tap-to-flip">
+                    <i class="bi bi-arrow-repeat"></i> Tap to flip
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="quiz-buttons">
+        <button class="btn-quiz btn-outline-custom" onclick="submitAnswer(false)">
+            <i class="bi bi-x-circle"></i> Don't Know
+        </button>
+        <button class="btn-quiz btn-success-custom" onclick="submitAnswer(true)">
+            <i class="bi bi-check-circle"></i> Know This
+        </button>
+    </div>
+</div>
+
+<form id="finishForm" asp-action="Finish" method="post" style="display: none;">
+    <input type="hidden" name="sessionId" value="@Model.SessionId" />
+</form>
+
+@section Scripts {
+    <script>
+        const cards = @Html.Raw(Json.Serialize(Model.Cards));
+        let currentIndex = 0;
+        const sessionId = @Model.SessionId;
+
+        function updateCard() {
+            if (currentIndex >= cards.length) {
+                document.getElementById('finishForm').submit();
+                return;
+            }
+
+            const card = cards[currentIndex];
+            document.getElementById('progressCounter').innerText = (currentIndex + 1) + '/' + cards.length;
+            document.getElementById('frontTerm').innerText = card.term;
+            document.getElementById('frontTranscription').innerText = card.transcription ? '[' + card.transcription + ']' : '';
+            document.getElementById('backTranslation').innerText = card.translation;
+            document.getElementById('backMeaning').innerText = card.meaning || '';
+            
+            document.querySelector('.quiz-card').classList.remove('flipped');
+        }
+
+        async function submitAnswer(isKnown) {
+            const wordId = cards[currentIndex].wordId;
+            
+            try {
+                const response = await fetch('/Quiz/SubmitAnswer', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        sessionId: sessionId,
+                        wordId: wordId,
+                        isKnown: isKnown
+                    })
+                });
+
+                if (response.ok) {
+                    currentIndex++;
+                    updateCard();
+                } else {
+                    showToast('Error submitting answer', 'danger');
+                }
+            } catch (error) {
+                console.error('Error:', error);
+                showToast('Network error', 'danger');
+            }
+        }
+
+        updateCard();
+    </script>
+}

--- a/Enrich/Enrich.Web/Views/Quiz/Setup.cshtml
+++ b/Enrich/Enrich.Web/Views/Quiz/Setup.cshtml
@@ -1,0 +1,145 @@
+@model Enrich.BLL.DTOs.QuizSetupDTO
+@{
+    ViewData["Title"] = "Quiz Setup";
+    Layout = "~/Views/Shared/_AppLayout.cshtml";
+    var categories = ViewBag.Categories as IEnumerable<string> ?? new List<string>();
+    var partsOfSpeech = ViewBag.PartsOfSpeech as IEnumerable<string> ?? new List<string>();
+}
+
+<style>
+    .setup-page {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 80vh;
+        font-family: 'Open Sans', sans-serif;
+    }
+
+    .setup-title {
+        font-size: 3.5rem;
+        font-weight: 800;
+        margin-bottom: 40px;
+        color: #212529;
+    }
+
+    .setup-card {
+        background: white;
+        border-radius: 24px;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+        width: 100%;
+        max-width: 600px;
+        padding: 40px;
+    }
+
+    .form-label {
+        font-weight: 700;
+        font-size: 0.9rem;
+        color: #495057;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 12px;
+    }
+
+    .custom-select, .custom-input {
+        background-color: #F8F9FA !important;
+        border: 1px solid #E9ECEF !important;
+        border-radius: 12px !important;
+        padding: 12px 16px !important;
+        font-size: 1rem !important;
+        font-weight: 500 !important;
+        color: #212529 !important;
+    }
+
+    .btn-start {
+        background-color: #198754;
+        color: white;
+        border-radius: 12px;
+        padding: 16px;
+        font-weight: 700;
+        font-size: 1.1rem;
+        border: none;
+        transition: all 0.2s;
+        margin-top: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+    }
+
+    .btn-start:hover {
+        background-color: #157347;
+        transform: translateY(-1px);
+    }
+</style>
+
+<div class="setup-page">
+    <h1 class="setup-title">Quiz Setup</h1>
+    
+    <div class="setup-card">
+        @if (TempData["Error"] != null)
+        {
+            <div class="alert alert-danger rounded-3 border-0 mb-4" style="background-color: #fff5f5; color: #dc3545;">
+                <i class="bi bi-exclamation-circle me-2"></i> @TempData["Error"]
+            </div>
+        }
+
+        <form asp-action="Start" method="post">
+            <div class="mb-4">
+                <label class="form-label">Category</label>
+                <select asp-for="Category" class="form-select custom-select">
+                    <option value="Any">Any Category</option>
+                    @foreach (var cat in categories)
+                    {
+                        <option value="@cat">@cat</option>
+                    }
+                </select>
+            </div>
+
+            <div class="mb-4">
+                <label class="form-label">Part of Speech</label>
+                <select asp-for="PartOfSpeech" class="form-select custom-select">
+                    <option value="Any">Any Part of Speech</option>
+                    @foreach (var pos in partsOfSpeech)
+                    {
+                        <option value="@pos">@pos</option>
+                    }
+                </select>
+            </div>
+
+            <div class="row mb-4">
+                <div class="col">
+                    <label class="form-label">Difficulty (Min)</label>
+                    <select asp-for="MinDifficulty" class="form-select custom-select">
+                        <option value="0">A1</option>
+                        <option value="1">A2</option>
+                        <option value="2">B1</option>
+                        <option value="3">B2</option>
+                        <option value="4">C1</option>
+                        <option value="5">C2</option>
+                    </select>
+                </div>
+                <div class="col">
+                    <label class="form-label">Difficulty (Max)</label>
+                    <select asp-for="MaxDifficulty" class="form-select custom-select">
+                        <option value="0">A1</option>
+                        <option value="1">A2</option>
+                        <option value="2">B1</option>
+                        <option value="3">B2</option>
+                        <option value="4">C1</option>
+                        <option value="5" selected>C2</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="mb-4">
+                <label class="form-label">Number of Words</label>
+                <input type="number" asp-for="WordCount" class="form-control custom-input" min="1" max="50" value="10" />
+            </div>
+
+            <button type="submit" class="btn-start w-100">
+                <i class="bi bi-play-fill fs-4"></i> Start Quiz Session
+            </button>
+        </form>
+    </div>
+</div>

--- a/Enrich/Enrich.Web/Views/Shared/_AppLayout.cshtml
+++ b/Enrich/Enrich.Web/Views/Shared/_AppLayout.cshtml
@@ -104,7 +104,7 @@
                     <ul class="nav flex-column nav-pills gap-1 mb-1">
                         <li class="nav-item">
                             <a asp-controller="Admin" asp-action="Browse"
-                               class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentController == "Admin" ? activeClass : inactiveClass)"
+                               class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentController == "Admin" && currentAction != "PendingBundles" ? activeClass : inactiveClass)"
                                style="font-weight: 500; font-size: 0.95rem;">
                                 <i class="bi bi-person-gear me-3 fs-6"></i>Manage users
                             </a>
@@ -124,7 +124,9 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a href="#" class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 text-dark" style="font-weight: 500; font-size: 0.95rem;">
+                            <a asp-controller="AdminBundle" asp-action="Index"
+                               class="nav-link d-flex align-items-center rounded-4 py-2 px-3 ms-2 me-3 @(currentController == "AdminBundle" ? activeClass : inactiveClass)"
+                               style="font-weight: 500; font-size: 0.95rem;">
                                 <i class="bi bi-folder-fill me-3 fs-6"></i>Manage collections
                             </a>
                         </li>

--- a/Enrich/Enrich.Web/Views/Word/MyWords.cshtml
+++ b/Enrich/Enrich.Web/Views/Word/MyWords.cshtml
@@ -248,6 +248,9 @@
                 <a asp-action="Create" class="btn btn-action primary">
                     <i class="bi bi-plus-lg me-1"></i> Add New Word
                 </a>
+                <a asp-controller="Quiz" asp-action="Setup" class="btn btn-action primary">
+                    <i class="bi bi-play-fill me-1"></i> Start Quiz
+                </a>
             </div>
 
             <div id="words-container" class="row g-3" data-page-size="@ViewData["PageSize"]"></div>


### PR DESCRIPTION
## Overview
This PR implements the functionality to save words directly to a user's personal library during study or quiz sessions.

## Key Changes
- **Service Layer**: Added `SaveWordToLibraryAsync` to `WordService` using the existing `Result` pattern.
- **Validation**: Implemented logic to prevent saving duplicate words to the user's library.
- **Controller**: Created a `POST /Words/AddToMyWords` endpoint in `WordController` to handle client requests.
- **Logging**: Added structured logging in English for both successful saves and validation failures.
- **Testing**: Added unit tests in `WordServiceTests` to cover success scenarios and duplicate entry prevention.

## Technical Details
- Followed the project's established architecture and naming conventions.
- Ensured compliance with StyleCop rules.
Closes #110